### PR TITLE
Fix message editing with media

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -46,6 +46,33 @@ ensure_database_schema()
 
 bot = telebot.TeleBot(config.token)
 
+# -------------------------------------------------
+# Utilidad para editar mensajes con o sin multimedia
+# -------------------------------------------------
+def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
+    """Edita texto o caption según el tipo de mensaje"""
+    try:
+        if getattr(message, 'content_type', 'text') == 'text':
+            bot.edit_message_text(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        else:
+            bot.edit_message_caption(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                caption=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        return True
+    except Exception as e:
+        print(f"Error editando mensaje de forma segura: {e}")
+        return False
+
 def it_first(chat_id):
     try:
         with open(files.working_log, encoding='utf-8') as f: 

--- a/main.py
+++ b/main.py
@@ -179,7 +179,7 @@ def inline(callback):
         else:
             try:
                 catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog()}"
-                bot.edit_message_text(chat_id=callback.message.chat.id, message_id=callback.message.message_id, text=catalog_text, reply_markup=key, parse_mode='Markdown')
+                dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
             except Exception as e:
                 print(f"DEBUG: Error editando mensaje: {e}")
 
@@ -245,19 +245,19 @@ def inline(callback):
                             parse_mode='Markdown'
                         )
             else:
-                bot.edit_message_text(
-                    chat_id=callback.message.chat.id,
-                    message_id=callback.message.message_id,
-                    text=formatted_info,
+                dop.safe_edit_message(
+                    bot,
+                    callback.message,
+                    formatted_info,
                     reply_markup=key,
                     parse_mode='Markdown'
                 )
         except Exception as e:
             print(f"DEBUG: Error editando mensaje con multimedia: {e}")
-            bot.edit_message_text(
-                chat_id=callback.message.chat.id,
-                message_id=callback.message.message_id,
-                text=dop.format_product_with_media(callback.data),
+            dop.safe_edit_message(
+                bot,
+                callback.message,
+                dop.format_product_with_media(callback.data),
                 reply_markup=key,
                 parse_mode='Markdown'
             )
@@ -280,10 +280,10 @@ def inline(callback):
             # Agregar header con emoji
             enhanced_additional = f"📋 **INFORMACIÓN ADICIONAL**\n{'-'*30}\n\n{additional_info}"
             
-            bot.edit_message_text(
-                chat_id=callback.message.chat.id,
-                message_id=callback.message.message_id,
-                text=enhanced_additional,
+            dop.safe_edit_message(
+                bot,
+                callback.message,
+                enhanced_additional,
                 reply_markup=key,
                 parse_mode='Markdown'
             )
@@ -308,8 +308,8 @@ def inline(callback):
                     start_message = bd['start']
                 start_message = start_message.replace('username', callback.message.chat.username)
                 start_message = start_message.replace('name', callback.message.from_user.first_name)
-                try: 
-                    bot.edit_message_text(chat_id=callback.message.chat.id, message_id=callback.message.message_id, text=start_message, reply_markup=key)
+                try:
+                    dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
                 except Exception as e:
                     print(f"DEBUG: Error editando mensaje: {e}")
 
@@ -338,11 +338,11 @@ def inline(callback):
 
 💡 **Tip:** Envía solo el número (ej: 5)"""
 
-                bot.edit_message_text(
-                    chat_id=callback.message.chat.id, 
-                    message_id=callback.message.message_id, 
-                    text=purchase_text, 
-                    reply_markup=key, 
+                dop.safe_edit_message(
+                    bot,
+                    callback.message,
+                    purchase_text,
+                    reply_markup=key,
                     parse_mode='Markdown'
                 )
             except Exception as e:

--- a/payments.py
+++ b/payments.py
@@ -97,14 +97,18 @@ def creat_bill_paypal(chat_id, callback_id, message_id, sum_amount, name_good, a
         key.add(b1)
         key.add(telebot.types.InlineKeyboardButton(text='Volver al inicio', callback_data='Volver al inicio'))
         
-        try: 
-            bot.edit_message_text(
-                chat_id=chat_id, 
-                message_id=message_id, 
-                text=f'Para comprar {name_good} cantidad {amount}\nTotal: ${sum_amount} USD\nHaz clic en "Pagar con PayPal" y completa el pago.\nLuego presiona "Verificar pago".', 
+        try:
+            dop.safe_edit_message(
+                bot,
+                type('obj', (object,), {
+                    'chat': type('chat', (object,), {'id': chat_id})(),
+                    'message_id': message_id,
+                    'content_type': 'text'
+                })(),
+                f'Para comprar {name_good} cantidad {amount}\nTotal: ${sum_amount} USD\nHaz clic en "Pagar con PayPal" y completa el pago.\nLuego presiona "Verificar pago".',
                 reply_markup=key
             )
-        except: 
+        except:
             pass
         
         he_client.append(chat_id)
@@ -130,13 +134,17 @@ def check_oplata_paypal(chat_id, username, callback_id, first_name, message_id):
             
             if payment.state == 'approved':
                 he_client.remove(chat_id)
-                try: 
-                    bot.edit_message_text(
-                        chat_id=chat_id, 
-                        message_id=message_id, 
-                        text='¡Pago de PayPal confirmado!\nAhora recibirás tu producto'
+                try:
+                    dop.safe_edit_message(
+                        bot,
+                        type('obj', (object,), {
+                            'chat': type('chat', (object,), {'id': chat_id})(),
+                            'message_id': message_id,
+                            'content_type': 'text'
+                        })(),
+                        '¡Pago de PayPal confirmado!\nAhora recibirás tu producto'
                     )
-                except: 
+                except:
                     pass
                 
                 # Entregar producto
@@ -185,11 +193,15 @@ def creat_bill_binance(chat_id, callback_id, message_id, sum_amount, name_good, 
     key.add(telebot.types.InlineKeyboardButton(text='🏠 Volver al inicio', callback_data='Volver al inicio'))
     
     # MENSAJE CORREGIDO - CON ID EN LAS INSTRUCCIONES
-    try: 
-        bot.edit_message_text(
-            chat_id=chat_id, 
-            message_id=message_id, 
-            text=f"""💳 **Pago con Binance Pay**
+    try:
+        dop.safe_edit_message(
+            bot,
+            type('obj', (object,), {
+                'chat': type('chat', (object,), {'id': chat_id})(),
+                'message_id': message_id,
+                'content_type': 'text'
+            })(),
+            f"""💳 **Pago con Binance Pay**
 
 📦 **Producto:** {name_good}
 🔢 **Cantidad:** {amount}
@@ -293,10 +305,14 @@ def check_oplata_binance(chat_id, username, callback_id, first_name, message_id)
     
     # Responder al cliente
     try:
-        bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=f"""⏳ **Pago en Verificación**
+        dop.safe_edit_message(
+            bot,
+            type('obj', (object,), {
+                'chat': type('chat', (object,), {'id': chat_id})(),
+                'message_id': message_id,
+                'content_type': 'text'
+            })(),
+            f"""⏳ **Pago en Verificación**
 
 ✅ Tu solicitud de pago ha sido enviada al administrador.
 
@@ -362,10 +378,14 @@ Gracias por tu compra.""", parse_mode='Markdown')
                     
                     # Confirmar al admin
                     try:
-                        bot.edit_message_text(
-                            chat_id=admin_chat_id,
-                            message_id=message_id,
-                            text=f"✅ **PAGO APROBADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} recibió su producto: {name_good}",
+                        dop.safe_edit_message(
+                            bot,
+                            type('obj', (object,), {
+                                'chat': type('chat', (object,), {'id': admin_chat_id})(),
+                                'message_id': message_id,
+                                'content_type': 'text'
+                            })(),
+                            f"✅ **PAGO APROBADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} recibió su producto: {name_good}",
                             parse_mode='Markdown'
                         )
                     except Exception as e:
@@ -397,10 +417,14 @@ Tu pago de ${payment_info['amount']} USD no pudo ser verificado.
                 
                 # Confirmar al admin
                 try:
-                    bot.edit_message_text(
-                        chat_id=admin_chat_id,
-                        message_id=message_id,
-                        text=f"❌ **PAGO RECHAZADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} fue notificado del rechazo.",
+                    dop.safe_edit_message(
+                        bot,
+                        type('obj', (object,), {
+                            'chat': type('chat', (object,), {'id': admin_chat_id})(),
+                            'message_id': message_id,
+                            'content_type': 'text'
+                        })(),
+                        f"❌ **PAGO RECHAZADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} fue notificado del rechazo.",
                         parse_mode='Markdown'
                     )
                 except Exception as e:


### PR DESCRIPTION
## Summary
- add `safe_edit_message` utility
- update callbacks in `main.py` to use safe edits
- use safe edits in PayPal/Binance payment flows

## Testing
- `python -m py_compile dop.py main.py payments.py`

------
https://chatgpt.com/codex/tasks/task_e_6858613a7f6c832eb2304f467428b134