### PR TITLE
Fix message editing with media

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -3,6 +3,32 @@ import config, dop, files
 
 bot = telebot.TeleBot(config.token)
 
+
+def show_discount_menu(chat_id):
+    """Mostrar menú de configuración de descuentos"""
+    config_dis = dop.get_discount_config()
+
+    status = 'Activado ✅' if config_dis['enabled'] else 'Desactivado ❌'
+    show_fake = 'Sí' if config_dis['show_fake_price'] else 'No'
+
+    user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+    toggle = 'Desactivar descuentos' if config_dis['enabled'] else 'Activar descuentos'
+    toggle_fake = 'Ocultar precios tachados' if config_dis['show_fake_price'] else 'Mostrar precios tachados'
+    user_markup.row(toggle)
+    user_markup.row('Cambiar texto', 'Cambiar multiplicador')
+    user_markup.row(toggle_fake)
+    user_markup.row('Vista previa', 'Volver al menú principal')
+
+    message = (
+        f"💸 *Configuración de Descuentos*\n\n"
+        f"Estado: {status}\n"
+        f"Texto: {config_dis['text']}\n"
+        f"Multiplicador: x{config_dis['multiplier']}\n"
+        f"Mostrar precios tachados: {show_fake}"
+    )
+
+    bot.send_message(chat_id, message, reply_markup=user_markup, parse_mode='Markdown')
+
 def in_adminka(chat_id, message_text, username, name_user):
     if chat_id in dop.get_adminlist():
         if message_text == 'Volver al menú principal' or message_text == '/adm':
@@ -14,6 +40,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('📦 Surtido', '➕ Producto')
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
+            user_markup.row('💸 Descuentos')
             user_markup.row('⚙️ Otros')
             bot.send_message(chat_id, '¡Has ingresado al panel de administración del bot!\nPara salir, presiona /start', reply_markup=user_markup)
 
@@ -291,6 +318,39 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('Volver al menú principal')
             bot.send_message(chat_id, 'Seleccione a qué grupo de usuarios desea enviar el boletín', reply_markup=user_markup)
 
+        elif '💸 Descuentos' == message_text:
+            show_discount_menu(chat_id)
+
+        elif 'Activar descuentos' == message_text or 'Desactivar descuentos' == message_text:
+            current = dop.get_discount_config()['enabled']
+            dop.update_discount_config(enabled=not current)
+            bot.send_message(chat_id, '✅ Estado de descuentos actualizado')
+            show_discount_menu(chat_id)
+
+        elif 'Mostrar precios tachados' == message_text or 'Ocultar precios tachados' == message_text:
+            current = dop.get_discount_config()['show_fake_price']
+            dop.update_discount_config(show_fake_price=not current)
+            bot.send_message(chat_id, '✅ Configuración de precios actualizada')
+            show_discount_menu(chat_id)
+
+        elif 'Cambiar texto' == message_text:
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Envíe el nuevo texto para los descuentos:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 33
+
+        elif 'Cambiar multiplicador' == message_text:
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Envíe el nuevo multiplicador (ej. 1.5):', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 34
+
+        elif 'Vista previa' == message_text:
+            preview = f"🛍️ **CATÁLOGO PREVIEW**\n{'-'*30}\n\n{dop.get_productcatalog()}"
+            bot.send_message(chat_id, preview, parse_mode='Markdown')
+
         elif 'A todos los usuarios' == message_text or 'Solo a los compradores' == message_text:
             if 'A todos los usuarios' == message_text: 
                 with open('data/Temp/' + str(chat_id) + '.txt', 'w', encoding='utf-8') as f:  
@@ -348,6 +408,7 @@ def text_analytics(message_text, chat_id):
                 user_markup.row('📦 Surtido', '➕ Producto')
                 user_markup.row('💰 Pagos')
                 user_markup.row('📊 Stats', '📣 Difusión')
+                user_markup.row('💸 Descuentos')
                 user_markup.row('⚙️ Otros')
                 bot.send_message(chat_id, 'Mensaje guardado exitosamente!', reply_markup=user_markup)
                 with shelve.open(files.sost_bd) as bd: 
@@ -724,8 +785,32 @@ def text_analytics(message_text, chat_id):
             else:
                 bot.send_message(chat_id, '❌ El producto no tiene multimedia asignada')
             
-            with shelve.open(files.sost_bd) as bd: 
+            with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
+
+        elif sost_num == 33:  # Recibir nuevo texto de descuento
+            if dop.update_discount_config(text=message_text):
+                bot.send_message(chat_id, '✅ Texto de descuento actualizado')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando texto')
+
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_discount_menu(chat_id)
+
+        elif sost_num == 34:  # Recibir nuevo multiplicador
+            try:
+                multiplier = float(message_text)
+                if dop.update_discount_config(multiplier=multiplier):
+                    bot.send_message(chat_id, f'✅ Multiplicador actualizado a {multiplier}')
+                else:
+                    bot.send_message(chat_id, '❌ Error actualizando multiplicador')
+            except ValueError:
+                bot.send_message(chat_id, '❌ Valor inválido, use punto decimal. Ej: 1.5')
+
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_discount_menu(chat_id)
 
 def ad_inline(callback_data, chat_id, message_id):
     if 'Volver al menú principal de administración' == callback_data:
@@ -737,6 +822,7 @@ def ad_inline(callback_data, chat_id, message_id):
         user_markup.row('📦 Surtido', '➕ Producto')
         user_markup.row('💰 Pagos')
         user_markup.row('📊 Stats', '📣 Difusión')
+        user_markup.row('💸 Descuentos')
         user_markup.row('⚙️ Otros')
         bot.delete_message(chat_id, message_id)
         bot.send_message(chat_id, '¡Has ingresado al panel de administración del bot!\nPara salir, presiona /start', reply_markup=user_markup)

--- a/dop.py
+++ b/dop.py
@@ -46,6 +46,33 @@ ensure_database_schema()
 
 bot = telebot.TeleBot(config.token)
 
+# -------------------------------------------------
+# Utilidad para editar mensajes con o sin multimedia
+# -------------------------------------------------
+def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
+    """Edita texto o caption según el tipo de mensaje"""
+    try:
+        if getattr(message, 'content_type', 'text') == 'text':
+            bot.edit_message_text(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        else:
+            bot.edit_message_caption(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                caption=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        return True
+    except Exception as e:
+        print(f"Error editando mensaje de forma segura: {e}")
+        return False
+
 def it_first(chat_id):
     try:
         with open(files.working_log, encoding='utf-8') as f: 

--- a/main.py
+++ b/main.py
@@ -179,7 +179,7 @@ def inline(callback):
         else:
             try:
                 catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog()}"
-                bot.edit_message_text(chat_id=callback.message.chat.id, message_id=callback.message.message_id, text=catalog_text, reply_markup=key, parse_mode='Markdown')
+                dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
             except Exception as e:
                 print(f"DEBUG: Error editando mensaje: {e}")
 
@@ -245,19 +245,19 @@ def inline(callback):
                             parse_mode='Markdown'
                         )
             else:
-                bot.edit_message_text(
-                    chat_id=callback.message.chat.id,
-                    message_id=callback.message.message_id,
-                    text=formatted_info,
+                dop.safe_edit_message(
+                    bot,
+                    callback.message,
+                    formatted_info,
                     reply_markup=key,
                     parse_mode='Markdown'
                 )
         except Exception as e:
             print(f"DEBUG: Error editando mensaje con multimedia: {e}")
-            bot.edit_message_text(
-                chat_id=callback.message.chat.id,
-                message_id=callback.message.message_id,
-                text=dop.format_product_with_media(callback.data),
+            dop.safe_edit_message(
+                bot,
+                callback.message,
+                dop.format_product_with_media(callback.data),
                 reply_markup=key,
                 parse_mode='Markdown'
             )
@@ -280,10 +280,10 @@ def inline(callback):
             # Agregar header con emoji
             enhanced_additional = f"📋 **INFORMACIÓN ADICIONAL**\n{'-'*30}\n\n{additional_info}"
             
-            bot.edit_message_text(
-                chat_id=callback.message.chat.id,
-                message_id=callback.message.message_id,
-                text=enhanced_additional,
+            dop.safe_edit_message(
+                bot,
+                callback.message,
+                enhanced_additional,
                 reply_markup=key,
                 parse_mode='Markdown'
             )
@@ -308,8 +308,8 @@ def inline(callback):
                     start_message = bd['start']
                 start_message = start_message.replace('username', callback.message.chat.username)
                 start_message = start_message.replace('name', callback.message.from_user.first_name)
-                try: 
-                    bot.edit_message_text(chat_id=callback.message.chat.id, message_id=callback.message.message_id, text=start_message, reply_markup=key)
+                try:
+                    dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
                 except Exception as e:
                     print(f"DEBUG: Error editando mensaje: {e}")
 
@@ -338,11 +338,11 @@ def inline(callback):
 
 💡 **Tip:** Envía solo el número (ej: 5)"""
 
-                bot.edit_message_text(
-                    chat_id=callback.message.chat.id, 
-                    message_id=callback.message.message_id, 
-                    text=purchase_text, 
-                    reply_markup=key, 
+                dop.safe_edit_message(
+                    bot,
+                    callback.message,
+                    purchase_text,
+                    reply_markup=key,
                     parse_mode='Markdown'
                 )
             except Exception as e:

--- a/payments.py
+++ b/payments.py
@@ -97,14 +97,18 @@ def creat_bill_paypal(chat_id, callback_id, message_id, sum_amount, name_good, a
         key.add(b1)
         key.add(telebot.types.InlineKeyboardButton(text='Volver al inicio', callback_data='Volver al inicio'))
         
-        try: 
-            bot.edit_message_text(
-                chat_id=chat_id, 
-                message_id=message_id, 
-                text=f'Para comprar {name_good} cantidad {amount}\nTotal: ${sum_amount} USD\nHaz clic en "Pagar con PayPal" y completa el pago.\nLuego presiona "Verificar pago".', 
+        try:
+            dop.safe_edit_message(
+                bot,
+                type('obj', (object,), {
+                    'chat': type('chat', (object,), {'id': chat_id})(),
+                    'message_id': message_id,
+                    'content_type': 'text'
+                })(),
+                f'Para comprar {name_good} cantidad {amount}\nTotal: ${sum_amount} USD\nHaz clic en "Pagar con PayPal" y completa el pago.\nLuego presiona "Verificar pago".',
                 reply_markup=key
             )
-        except: 
+        except:
             pass
         
         he_client.append(chat_id)
@@ -130,13 +134,17 @@ def check_oplata_paypal(chat_id, username, callback_id, first_name, message_id):
             
             if payment.state == 'approved':
                 he_client.remove(chat_id)
-                try: 
-                    bot.edit_message_text(
-                        chat_id=chat_id, 
-                        message_id=message_id, 
-                        text='¡Pago de PayPal confirmado!\nAhora recibirás tu producto'
+                try:
+                    dop.safe_edit_message(
+                        bot,
+                        type('obj', (object,), {
+                            'chat': type('chat', (object,), {'id': chat_id})(),
+                            'message_id': message_id,
+                            'content_type': 'text'
+                        })(),
+                        '¡Pago de PayPal confirmado!\nAhora recibirás tu producto'
                     )
-                except: 
+                except:
                     pass
                 
                 # Entregar producto
@@ -185,11 +193,15 @@ def creat_bill_binance(chat_id, callback_id, message_id, sum_amount, name_good, 
     key.add(telebot.types.InlineKeyboardButton(text='🏠 Volver al inicio', callback_data='Volver al inicio'))
     
     # MENSAJE CORREGIDO - CON ID EN LAS INSTRUCCIONES
-    try: 
-        bot.edit_message_text(
-            chat_id=chat_id, 
-            message_id=message_id, 
-            text=f"""💳 **Pago con Binance Pay**
+    try:
+        dop.safe_edit_message(
+            bot,
+            type('obj', (object,), {
+                'chat': type('chat', (object,), {'id': chat_id})(),
+                'message_id': message_id,
+                'content_type': 'text'
+            })(),
+            f"""💳 **Pago con Binance Pay**
 
 📦 **Producto:** {name_good}
 🔢 **Cantidad:** {amount}
@@ -293,10 +305,14 @@ def check_oplata_binance(chat_id, username, callback_id, first_name, message_id)
     
     # Responder al cliente
     try:
-        bot.edit_message_text(
-            chat_id=chat_id,
-            message_id=message_id,
-            text=f"""⏳ **Pago en Verificación**
+        dop.safe_edit_message(
+            bot,
+            type('obj', (object,), {
+                'chat': type('chat', (object,), {'id': chat_id})(),
+                'message_id': message_id,
+                'content_type': 'text'
+            })(),
+            f"""⏳ **Pago en Verificación**
 
 ✅ Tu solicitud de pago ha sido enviada al administrador.
 
@@ -362,10 +378,14 @@ Gracias por tu compra.""", parse_mode='Markdown')
                     
                     # Confirmar al admin
                     try:
-                        bot.edit_message_text(
-                            chat_id=admin_chat_id,
-                            message_id=message_id,
-                            text=f"✅ **PAGO APROBADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} recibió su producto: {name_good}",
+                        dop.safe_edit_message(
+                            bot,
+                            type('obj', (object,), {
+                                'chat': type('chat', (object,), {'id': admin_chat_id})(),
+                                'message_id': message_id,
+                                'content_type': 'text'
+                            })(),
+                            f"✅ **PAGO APROBADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} recibió su producto: {name_good}",
                             parse_mode='Markdown'
                         )
                     except Exception as e:
@@ -397,10 +417,14 @@ Tu pago de ${payment_info['amount']} USD no pudo ser verificado.
                 
                 # Confirmar al admin
                 try:
-                    bot.edit_message_text(
-                        chat_id=admin_chat_id,
-                        message_id=message_id,
-                        text=f"❌ **PAGO RECHAZADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} fue notificado del rechazo.",
+                    dop.safe_edit_message(
+                        bot,
+                        type('obj', (object,), {
+                            'chat': type('chat', (object,), {'id': admin_chat_id})(),
+                            'message_id': message_id,
+                            'content_type': 'text'
+                        })(),
+                        f"❌ **PAGO RECHAZADO por Admin {admin_chat_id}**\n\nUsuario {user_chat_id} fue notificado del rechazo.",
                         parse_mode='Markdown'
                     )
                 except Exception as e:


### PR DESCRIPTION
## Summary
- add `safe_edit_message` utility
- update callbacks in `main.py` to use safe edits
- use safe edits in PayPal/Binance payment flows
- add admin discount management menu

## Testing
- `python -m py_compile dop.py main.py payments.py adminka.py`


------
https://chatgpt.com/codex/tasks/task_e_6858613a7f6c832eb2304f467428b134