### PR TITLE
Add subscription management

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,18 @@ Con el módulo `subscriptions.py` puedes:
 2. Crear suscripciones para los usuarios con `create_user_subscription()` una
    vez que se complete un pago.
 3. Ejecutar `check_subscriptions()` de forma diaria (por ejemplo mediante cron)
-   para enviar recordatorios, marcar suscripciones vencidas y suspender las que
-   superen el periodo de gracia.
-4. Consultar vencimientos próximos con `get_upcoming_subscriptions()` para
+   para enviar recordatorios, renovar automáticamente si está configurado y
+   suspender las suscripciones vencidas.
+4. Cancelar suscripciones con `cancel_subscription()` y consultar todas las de
+   un usuario mediante `get_user_subscriptions()`.
+5. Consultar vencimientos próximos con `get_upcoming_subscriptions()` para
    mostrar un dashboard o generar reportes.
+
+Para ejecutar el proceso diario de forma sencilla puedes programar `subscription_cron.py` con tu gestor de tareas preferido:
+
+```bash
+python subscription_cron.py
+```
 
 ## Licencia
 

--- a/adminka.py
+++ b/adminka.py
@@ -38,6 +38,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
             user_markup.row('💬 Respuestas')
             user_markup.row('📦 Surtido', '➕ Producto')
+            user_markup.row('💼 Suscripciones')
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
             user_markup.row('💸 Descuentos')
@@ -266,21 +267,31 @@ def in_adminka(chat_id, message_text, username, name_user):
 
         elif '➕ Producto' == message_text:
             key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
+            key.add(
+                telebot.types.InlineKeyboardButton(
+                    text='Cancelar y volver al menú principal de administración',
+                    callback_data='Volver al menú principal de administración'))
             con = sqlite3.connect(files.main_db)
             cursor = con.cursor()
             cursor.execute("SELECT name, price FROM goods;")
             a = 0
-            user_markup = telebot.types.ReplyKeyboardMarkup(True, True) 
+            user_markup = telebot.types.ReplyKeyboardMarkup(True, True)
             for name, price in cursor.fetchall():
                 a += 1
                 user_markup.row(name)
-            if a == 0: 
-                bot.send_message(chat_id, '¡No se ha creado ninguna posición todavía!')
+            user_markup.row('Volver al menú principal')
+            if a == 0:
+                bot.send_message(
+                    chat_id,
+                    '¡No se ha creado ninguna posición todavía!',
+                    reply_markup=user_markup)
             else:
-                user_markup.row('Volver al menú principal')
-                bot.send_message(chat_id, '¿De qué posición desea cargar productos?', reply_markup=user_markup, parse_mode='MarkDown')
-                with shelve.open(files.sost_bd) as bd: 
+                bot.send_message(
+                    chat_id,
+                    '¿De qué posición desea cargar productos?',
+                    reply_markup=user_markup,
+                    parse_mode='MarkDown')
+                with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 10
             con.close()
 
@@ -318,6 +329,13 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('Volver al menú principal')
             bot.send_message(chat_id, 'Seleccione a qué grupo de usuarios desea enviar el boletín', reply_markup=user_markup)
 
+        elif '💼 Suscripciones' == message_text:
+            user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+            user_markup.row('Crear plan de suscripción')
+            user_markup.row('Lista de planes')
+            user_markup.row('Volver al menú principal')
+            bot.send_message(chat_id, 'Gestión de planes de suscripción:', reply_markup=user_markup)
+
         elif '💸 Descuentos' == message_text:
             show_discount_menu(chat_id)
 
@@ -346,6 +364,23 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, 'Envíe el nuevo multiplicador (ej. 1.5):', reply_markup=key)
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 34
+
+        elif 'Crear plan de suscripción' == message_text:
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Ingrese el nombre del plan:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 40
+
+        elif 'Lista de planes' == message_text:
+            plans = subscriptions.get_all_subscription_products()
+            if plans:
+                text = '📋 *Planes disponibles:*\n\n'
+                for pid, name, desc, price, currency, duration, unit, *_ in plans:
+                    text += f'- {pid}. {name} - {price} {currency}/{duration}{unit}\n'
+            else:
+                text = 'No hay planes de suscripción.'
+            bot.send_message(chat_id, text, parse_mode='Markdown')
 
         elif 'Vista previa' == message_text:
             preview = f"🛍️ **CATÁLOGO PREVIEW**\n{'-'*30}\n\n{dop.get_productcatalog()}"
@@ -818,6 +853,50 @@ def text_analytics(message_text, chat_id):
                 del bd[str(chat_id)]
             show_discount_menu(chat_id)
 
+        elif sost_num == 40:  # Nombre del plan de suscripción
+            with open('data/Temp/' + str(chat_id) + 'sub_name.txt', 'w', encoding='utf-8') as f:
+                f.write(message_text)
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Ingrese una descripción para el plan:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 41
+
+        elif sost_num == 41:  # Descripción del plan
+            with open('data/Temp/' + str(chat_id) + 'sub_desc.txt', 'w', encoding='utf-8') as f:
+                f.write(message_text)
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Precio en USD del plan:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 42
+
+        elif sost_num == 42:  # Precio del plan
+            with open('data/Temp/' + str(chat_id) + 'sub_price.txt', 'w', encoding='utf-8') as f:
+                f.write(message_text)
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Duración en días de la suscripción:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 43
+
+        elif sost_num == 43:  # Duración del plan
+            try:
+                duration = int(message_text)
+                with open('data/Temp/' + str(chat_id) + 'sub_name.txt', encoding='utf-8') as f:
+                    name = f.read()
+                with open('data/Temp/' + str(chat_id) + 'sub_desc.txt', encoding='utf-8') as f:
+                    desc = f.read()
+                with open('data/Temp/' + str(chat_id) + 'sub_price.txt', encoding='utf-8') as f:
+                    price = f.read()
+                subscriptions.add_subscription_product(name, desc, int(price), duration)
+                bot.send_message(chat_id, '✅ Plan de suscripción creado con éxito')
+            except Exception as e:
+                bot.send_message(chat_id, f'❌ Error creando plan: {e}')
+
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+
 def ad_inline(callback_data, chat_id, message_id):
     if 'Volver al menú principal de administración' == callback_data:
         if dop.get_sost(chat_id) is True:
@@ -826,6 +905,7 @@ def ad_inline(callback_data, chat_id, message_id):
         user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
         user_markup.row('💬 Respuestas')
         user_markup.row('📦 Surtido', '➕ Producto')
+        user_markup.row('💼 Suscripciones')
         user_markup.row('💰 Pagos')
         user_markup.row('📊 Stats', '📣 Difusión')
         user_markup.row('💸 Descuentos')

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 import telebot, shelve, sqlite3, os
-import config, dop, payments, adminka, files
+import config, dop, payments, adminka, files, subscriptions
 
 print("🚀 DEBUG: main.py - Script iniciado.")
 
@@ -47,6 +47,7 @@ def message_send(message):
             elif dop.check_message('start') is True:
                 key = telebot.types.InlineKeyboardMarkup()
                 key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+                key.add(telebot.types.InlineKeyboardButton(text='🌀 Suscripciones', callback_data='Ir al catálogo de suscripciones'))
                 with shelve.open(files.bot_message_bd) as bd: 
                     start_message = bd['start']
                 start_message = start_message.replace('username', message.chat.username)
@@ -183,6 +184,19 @@ def inline(callback):
             except Exception as e:
                 print(f"DEBUG: Error editando mensaje: {e}")
 
+    elif callback.data == 'Ir al catálogo de suscripciones':
+        plans = subscriptions.get_all_subscription_products()
+        key = telebot.types.InlineKeyboardMarkup()
+        for plan in plans:
+            key.add(telebot.types.InlineKeyboardButton(text=f'🌀 {plan[1]}', callback_data=f'SUBP_{plan[0]}'))
+        key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+
+        if not plans:
+            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='No hay planes disponibles')
+        else:
+            catalog_text = '🌀 *PLANES DISPONIBLES*\n\nSeleccione un plan para ver detalles.'
+            dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
+
     # Mostrar información del producto
     elif callback.data in the_goods:
         with open('data/Temp/' + str(callback.message.chat.id) + 'good_name.txt', 'w', encoding='utf-8') as f: 
@@ -295,6 +309,41 @@ def inline(callback):
             print(f"DEBUG: Error mostrando información adicional: {e}")
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='❌ Error cargando información')
 
+    elif callback.data.startswith('SUBP_'):
+        sub_id = int(callback.data.split('_')[1])
+        plan = subscriptions.get_subscription_product(sub_id)
+        if not plan:
+            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='Plan no encontrado')
+        else:
+            _, name, desc, price, currency, duration, unit, *_ = plan
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='💳 Suscribirme', callback_data=f'BUY_SUB_{sub_id}'))
+            key.add(telebot.types.InlineKeyboardButton(text='🔙 Suscripciones', callback_data='Ir al catálogo de suscripciones'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            text = (f"**{name}**\n\n{desc}\n\nPrecio: {price} {currency}\nDuración: {duration} {unit}")
+            dop.safe_edit_message(bot, callback.message, text, reply_markup=key, parse_mode='Markdown')
+
+    elif callback.data.startswith('BUY_SUB_'):
+        sub_id = int(callback.data.split('_')[2])
+        plan = subscriptions.get_subscription_product(sub_id)
+        if not plan:
+            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='Plan no disponible')
+        else:
+            _, name, desc, price, currency, duration, unit, *_ = plan
+            key = telebot.types.InlineKeyboardMarkup()
+            if dop.check_vklpayments('paypal') == '✅':
+                key.add(telebot.types.InlineKeyboardButton(text='💳 PayPal', callback_data='PayPal'))
+            if dop.check_vklpayments('binance') == '✅':
+                key.add(telebot.types.InlineKeyboardButton(text='🟡 Binance Pay', callback_data='Binance'))
+            key.add(telebot.types.InlineKeyboardButton(text='🔙 Plan', callback_data=f'SUBP_{sub_id}'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            dop.safe_edit_message(bot, callback.message, f'🌀 *{name}*\nPrecio: {price} {currency}\nDuración: {duration} {unit}\n\nSelecciona método de pago:', reply_markup=key, parse_mode='Markdown')
+            with open('data/Temp/' + str(callback.message.chat.id) + 'good_name.txt', 'w', encoding='utf-8') as f:
+                f.write(f'SUB:{sub_id}')
+            with open('data/Temp/' + str(callback.message.chat.id) + '.txt', 'w', encoding='utf-8') as f:
+                f.write('1\n')
+                f.write(str(price) + '\n')
+
     elif callback.data == 'Volver al inicio':
         if callback.message.chat.username:
             if dop.get_sost(callback.message.chat.id) is True: 
@@ -303,6 +352,7 @@ def inline(callback):
                         del bd[str(callback.message.chat.id)]
             key = telebot.types.InlineKeyboardMarkup()
             key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+            key.add(telebot.types.InlineKeyboardButton(text='🌀 Suscripciones', callback_data='Ir al catálogo de suscripciones'))
             if dop.check_message('start'):
                 with shelve.open(files.bot_message_bd) as bd: 
                     start_message = bd['start']
@@ -316,39 +366,44 @@ def inline(callback):
     elif callback.data == 'Comprar':
         with open('data/Temp/' + str(callback.message.chat.id) + 'good_name.txt', encoding='utf-8') as f: 
             name_good = f.read()
-        if dop.amount_of_goods(name_good) == 0:
+        if not name_good.startswith('SUB:') and dop.amount_of_goods(name_good) == 0:
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='❌ Producto agotado - No disponible para compra')
         elif dop.payments_checkvkl() == None:
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='💳 Los pagos están temporalmente desactivados')
         else:
             key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='🔙 Volver al producto', callback_data=name_good))
+            back_cb = name_good if not name_good.startswith('SUB:') else f'SUBP_{name_good.split(":")[1]}'
+            key.add(telebot.types.InlineKeyboardButton(text='🔙 Volver al producto', callback_data=back_cb))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
             
-            try: 
-                purchase_text = f"""🛒 **REALIZAR COMPRA**
-{'-'*25}
+            if name_good.startswith('SUB:'):
+                sub_id = int(name_good.split(':')[1])
+                plan = subscriptions.get_subscription_product(sub_id)
+                if plan:
+                    _, name, desc, price, currency, duration, unit, *_ = plan
+                    purchase_text = f"🌀 *{name}*\nPrecio: {price} {currency}\nDuración: {duration} {unit}"
+                    dop.safe_edit_message(bot, callback.message, purchase_text, reply_markup=key, parse_mode='Markdown')
+                    with open('data/Temp/' + str(callback.message.chat.id) + '.txt', 'w', encoding='utf-8') as f:
+                        f.write('1\n')
+                        f.write(str(price) + '\n')
+                else:
+                    bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='Plan no disponible')
+                    return
+            else:
+                try:
+                    purchase_text = f"""🛒 **REALIZAR COMPRA**\n{'-'*25}\n\n📦 **Producto:** {name_good}\n\n🔢 **Ingresa la cantidad** que deseas comprar:\n\n📊 **Cantidad mínima:** {str(dop.get_minimum(name_good))} unidades\n📦 **Stock disponible:** {str(dop.amount_of_goods(name_good))} unidades\n\n💡 **Tip:** Envía solo el número (ej: 5)"""
 
-📦 **Producto:** {name_good}
-
-🔢 **Ingresa la cantidad** que deseas comprar:
-
-📊 **Cantidad mínima:** {str(dop.get_minimum(name_good))} unidades
-📦 **Stock disponible:** {str(dop.amount_of_goods(name_good))} unidades
-
-💡 **Tip:** Envía solo el número (ej: 5)"""
-
-                dop.safe_edit_message(
-                    bot,
-                    callback.message,
-                    purchase_text,
-                    reply_markup=key,
-                    parse_mode='Markdown'
-                )
-            except Exception as e:
-                print(f"DEBUG: Error editando mensaje: {e}")
-            with shelve.open(files.sost_bd) as bd: 
-                bd[str(callback.message.chat.id)] = 22
+                    dop.safe_edit_message(
+                        bot,
+                        callback.message,
+                        purchase_text,
+                        reply_markup=key,
+                        parse_mode='Markdown'
+                    )
+                except Exception as e:
+                    print(f"DEBUG: Error editando mensaje: {e}")
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(callback.message.chat.id)] = 22
 
     # Callbacks de pagos
     elif callback.data == 'PayPal' or callback.data == 'Binance':

--- a/payments.py
+++ b/payments.py
@@ -1,5 +1,6 @@
 import telebot, time, shelve, requests, json
-import dop, config, files
+from datetime import datetime, timedelta
+import dop, config, files, subscriptions
 
 bot = telebot.TeleBot(config.token)
 
@@ -449,25 +450,37 @@ def deliver_product(chat_id, username, first_name, name_good, amount, sum_amount
     """Función común para entregar productos"""
     try:
         print(f"DEBUG: Entregando producto {name_good} a usuario {chat_id}")
-        
-        # Entregar producto
-        text = ''
-        for i in range(int(amount)):
-            if dop.get_goodformat(name_good) == 'file':
-                product_data = dop.get_tovar(name_good)
-                if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
-                    bot.send_document(chat_id, product_data)
-                else:
-                    bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
-            elif dop.get_goodformat(name_good) == 'text':
-                product_data = dop.get_tovar(name_good)
-                if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
-                    text += product_data + '\n'
-                else:
-                    bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
-        
-        if dop.get_goodformat(name_good) == 'text' and text.strip(): 
-            bot.send_message(chat_id, text)
+
+        if name_good.startswith('SUB:'):
+            sub_id = int(name_good.split(':')[1])
+            product = subscriptions.get_subscription_product(sub_id)
+            if product:
+                _, name, desc, price, currency, duration, unit, *_ = product
+                subscriptions.create_user_subscription(chat_id, sub_id, payment_method)
+                end_date = (datetime.utcnow() + timedelta(**{unit: duration})).date()
+                bot.send_message(chat_id, f'✅ Suscripción *{name}* activada hasta {end_date}', parse_mode='Markdown')
+                name_good = name
+            else:
+                bot.send_message(chat_id, '❌ Plan de suscripción no encontrado')
+        else:
+            # Entregar producto físico/digital
+            text = ''
+            for i in range(int(amount)):
+                if dop.get_goodformat(name_good) == 'file':
+                    product_data = dop.get_tovar(name_good)
+                    if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
+                        bot.send_document(chat_id, product_data)
+                    else:
+                        bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
+                elif dop.get_goodformat(name_good) == 'text':
+                    product_data = dop.get_tovar(name_good)
+                    if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
+                        text += product_data + '\n'
+                    else:
+                        bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
+
+            if dop.get_goodformat(name_good) == 'text' and text.strip():
+                bot.send_message(chat_id, text)
         
         # Mensaje después de compra
         if dop.check_message('after_buy') is True:

--- a/subscription_cron.py
+++ b/subscription_cron.py
@@ -1,0 +1,4 @@
+import subscriptions
+
+if __name__ == "__main__":
+    subscriptions.check_subscriptions()

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -102,6 +102,17 @@ def get_subscription_product(product_id):
     return row
 
 
+def get_all_subscription_products():
+    """Obtener todos los planes de suscripción disponibles"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cursor = conn.cursor()
+    cursor.execute('SELECT * FROM subscription_products')
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
+
 # ---------------------------------------------------------------------------
 # Funciones para manejar suscripciones de clientes
 # ---------------------------------------------------------------------------
@@ -136,8 +147,13 @@ def create_user_subscription(user_id, product_id, payment_method,
     return True
 
 
-def renew_subscription(subscription_id):
-    """Renovar una suscripción existente"""
+def renew_subscription(subscription_id, apply_early_discount=False):
+    """Renovar una suscripción existente.
+
+    Si ``apply_early_discount`` es ``True`` se registra en el historial con la
+    etiqueta ``early``. El cálculo del descuento se debe gestionar en el sistema
+    de pagos externo.
+    """
     init_subscription_db()
     conn = sqlite3.connect(files.main_db)
     cursor = conn.cursor()
@@ -159,7 +175,12 @@ def renew_subscription(subscription_id):
 
     end_date = datetime.fromisoformat(end_date_str)
     new_end = end_date + timedelta(**{duration_unit: duration})
-    new_history = (history or '') + f"|renewed:{datetime.utcnow().isoformat()}"
+    tag = 'renewed'
+    if apply_early_discount:
+        tag += ':early'
+    else:
+        tag += ''
+    new_history = (history or '') + f"|{tag}:{datetime.utcnow().isoformat()}"
 
     cursor.execute(
         '''UPDATE user_subscriptions
@@ -184,6 +205,44 @@ def suspend_subscription(subscription_id):
     conn.close()
     log_action('suspended', subscription_id)
     return True
+
+
+def cancel_subscription(subscription_id):
+    """Cancelar una suscripción manualmente."""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        'UPDATE user_subscriptions SET status = ? WHERE id = ?',
+        ('canceled', subscription_id))
+    conn.commit()
+    conn.close()
+    log_action('canceled', subscription_id)
+    return True
+
+
+def get_user_subscriptions(user_id):
+    """Obtener todas las suscripciones de un usuario."""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT * FROM user_subscriptions WHERE user_id = ?', (user_id,))
+    rows = cursor.fetchall()
+    conn.close()
+    return rows
+
+
+def get_subscription_status(subscription_id):
+    """Devolver el estado actual de una suscripción."""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cursor = conn.cursor()
+    cursor.execute(
+        'SELECT status FROM user_subscriptions WHERE id = ?', (subscription_id,))
+    row = cursor.fetchone()
+    conn.close()
+    return row[0] if row else None
 
 
 def log_action(action, subscription_id):
@@ -247,8 +306,19 @@ def check_subscriptions():
             status = 'due'
             log_action('due', sub_id)
 
-        # Verificación de vencimiento
+        # Verificación de vencimiento y renovaciones automáticas
         if now > end_date:
+            if auto_renew:
+                renewed = renew_subscription(sub_id)
+                if renewed:
+                    log_action('auto_renew', sub_id)
+                    try:
+                        bot.send_message(
+                            user_id,
+                            f"🔄 Suscripción a {name} renovada automáticamente.")
+                    except Exception:
+                        pass
+                    continue
             if grace_period and now <= end_date + timedelta(days=grace_period):
                 if status != 'expired':
                     conn = sqlite3.connect(files.main_db)


### PR DESCRIPTION
## Summary
- integrate subscription catalog and purchase flow into main bot
- allow admins to manage subscription plans in adminka
- support subscription delivery in payment module
- expose function to list all subscription products

## Testing
- `python -m py_compile adminka.py subscriptions.py subscription_cron.py main.py payments.py`

------
https://chatgpt.com/codex/tasks/task_e_68589dc76b68832e81df308140f7a7db