### PR TITLE
Enable multimedia for subscription products

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1,5 +1,5 @@
 import telebot, sqlite3, shelve, os
-import config, dop, files
+import config, dop, files, subscriptions
 
 bot = telebot.TeleBot(config.token)
 

--- a/main.py
+++ b/main.py
@@ -309,19 +309,49 @@ def inline(callback):
             print(f"DEBUG: Error mostrando información adicional: {e}")
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='❌ Error cargando información')
 
+    elif callback.data.startswith('SUBINFO_'):
+        sub_id = int(callback.data.split('_')[1])
+        plan = subscriptions.get_subscription_product(sub_id)
+        if not plan:
+            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='Plan no encontrado')
+        else:
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='🔙 Volver al plan', callback_data=f'SUBP_{sub_id}'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            info = subscriptions.format_plan_additional_info(sub_id)
+            enhanced = f"📋 **INFORMACIÓN ADICIONAL**\n{'-'*30}\n\n{info}"
+            dop.safe_edit_message(bot, callback.message, enhanced, reply_markup=key, parse_mode='Markdown')
+
     elif callback.data.startswith('SUBP_'):
         sub_id = int(callback.data.split('_')[1])
         plan = subscriptions.get_subscription_product(sub_id)
         if not plan:
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='Plan no encontrado')
         else:
-            _, name, desc, price, currency, duration, unit, *_ = plan
             key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='💳 Suscribirme', callback_data=f'BUY_SUB_{sub_id}'))
-            key.add(telebot.types.InlineKeyboardButton(text='🔙 Suscripciones', callback_data='Ir al catálogo de suscripciones'))
-            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
-            text = (f"**{name}**\n\n{desc}\n\nPrecio: {price} {currency}\nDuración: {duration} {unit}")
-            dop.safe_edit_message(bot, callback.message, text, reply_markup=key, parse_mode='Markdown')
+            if subscriptions.has_additional_description(plan[1]):
+                key.add(telebot.types.InlineKeyboardButton(text="ℹ️ Más información", callback_data=f"SUBINFO_{sub_id}"))
+            key.add(telebot.types.InlineKeyboardButton(text="💳 Suscribirme", callback_data=f"BUY_SUB_{sub_id}"))
+            key.add(telebot.types.InlineKeyboardButton(text="🔙 Suscripciones", callback_data="Ir al catálogo de suscripciones"))
+            key.add(telebot.types.InlineKeyboardButton(text="🏠 Inicio", callback_data="Volver al inicio"))
+            media = subscriptions.get_plan_media(plan[1])
+            formatted = subscriptions.format_plan_with_media(sub_id)
+            if media and media["type"] in ("photo", "video"):
+                try:
+                    input_media = telebot.types.InputMediaPhoto if media["type"] == "photo" else telebot.types.InputMediaVideo
+                    bot.edit_message_media(chat_id=callback.message.chat.id, message_id=callback.message.message_id, media=input_media(media=media["file_id"], caption=formatted, parse_mode="Markdown"), reply_markup=key)
+                except Exception:
+                    dop.safe_edit_message(bot, callback.message, formatted, reply_markup=key, parse_mode="Markdown")
+            elif media and media["type"] in ("document", "audio", "animation"):
+                bot.delete_message(callback.message.chat.id, callback.message.message_id)
+                if media["type"] == "document":
+                    bot.send_document(callback.message.chat.id, media["file_id"], caption=formatted, reply_markup=key, parse_mode="Markdown")
+                elif media["type"] == "audio":
+                    bot.send_audio(callback.message.chat.id, media["file_id"], caption=formatted, reply_markup=key, parse_mode="Markdown")
+                else:
+                    bot.send_animation(callback.message.chat.id, media["file_id"], caption=formatted, reply_markup=key, parse_mode="Markdown")
+            else:
+                dop.safe_edit_message(bot, callback.message, formatted, reply_markup=key, parse_mode="Markdown")
 
     elif callback.data.startswith('BUY_SUB_'):
         sub_id = int(callback.data.split('_')[2])

--- a/payments.py
+++ b/payments.py
@@ -455,10 +455,18 @@ def deliver_product(chat_id, username, first_name, name_good, amount, sum_amount
             sub_id = int(name_good.split(':')[1])
             product = subscriptions.get_subscription_product(sub_id)
             if product:
-                _, name, desc, price, currency, duration, unit, *_ = product
+                (_, name, desc, price, currency, duration, unit,
+                 *_, additional_desc, media_file_id, media_type,
+                 media_caption, delivery_format, delivery_content) = product
                 subscriptions.create_user_subscription(chat_id, sub_id, payment_method)
                 end_date = (datetime.utcnow() + timedelta(**{unit: duration})).date()
                 bot.send_message(chat_id, f'✅ Suscripción *{name}* activada hasta {end_date}', parse_mode='Markdown')
+
+                if delivery_format == 'text' and delivery_content:
+                    bot.send_message(chat_id, delivery_content)
+                elif delivery_format == 'file' and delivery_content:
+                    bot.send_document(chat_id, delivery_content)
+
                 name_good = name
             else:
                 bot.send_message(chat_id, '❌ Plan de suscripción no encontrado')

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -35,9 +35,38 @@ def init_subscription_db():
                grace_period INTEGER DEFAULT 0,
                auto_renew INTEGER DEFAULT 1,
                early_discount INTEGER DEFAULT 0,
-               notification_days TEXT DEFAULT "{DEFAULT_NOTIFICATION_DAYS}"
+               notification_days TEXT DEFAULT "{DEFAULT_NOTIFICATION_DAYS}",
+               additional_description TEXT DEFAULT '',
+               media_file_id TEXT,
+               media_type TEXT,
+               media_caption TEXT,
+               delivery_format TEXT DEFAULT 'none',
+               delivery_content TEXT
         )'''
     )
+
+    # Asegurar columnas adicionales por compatibilidad
+    cursor.execute("PRAGMA table_info(subscription_products)")
+    existing_cols = [c[1] for c in cursor.fetchall()]
+    alter_commands = []
+    if 'additional_description' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN additional_description TEXT DEFAULT ''")
+    if 'media_file_id' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN media_file_id TEXT")
+    if 'media_type' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN media_type TEXT")
+    if 'media_caption' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN media_caption TEXT")
+    if 'delivery_format' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN delivery_format TEXT DEFAULT 'none'")
+    if 'delivery_content' not in existing_cols:
+        alter_commands.append("ALTER TABLE subscription_products ADD COLUMN delivery_content TEXT")
+
+    for cmd in alter_commands:
+        try:
+            cursor.execute(cmd)
+        except Exception:
+            pass
 
     cursor.execute(
         '''CREATE TABLE IF NOT EXISTS user_subscriptions (
@@ -70,7 +99,12 @@ def add_subscription_product(name, description, price, duration,
                              service_type='default', status='active',
                              grace_period=0, auto_renew=True,
                              early_discount=0,
-                             notification_days=DEFAULT_NOTIFICATION_DAYS):
+                             notification_days=DEFAULT_NOTIFICATION_DAYS,
+                             additional_description='',
+                             media_file_id=None, media_type=None,
+                             media_caption=None,
+                             delivery_format='none',
+                             delivery_content=None):
     """Agregar un nuevo producto de suscripción"""
     init_subscription_db()
     conn = sqlite3.connect(files.main_db)
@@ -79,11 +113,15 @@ def add_subscription_product(name, description, price, duration,
         '''INSERT INTO subscription_products
            (name, description, price, currency, duration, duration_unit,
             service_type, status, grace_period, auto_renew,
-            early_discount, notification_days)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+            early_discount, notification_days,
+            additional_description, media_file_id, media_type,
+            media_caption, delivery_format, delivery_content)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
         (name, description, price, currency, duration, duration_unit,
          service_type, status, grace_period, int(auto_renew),
-         early_discount, notification_days)
+         early_discount, notification_days,
+         additional_description, media_file_id, media_type,
+         media_caption, delivery_format, delivery_content)
     )
     conn.commit()
     conn.close()
@@ -111,6 +149,201 @@ def get_all_subscription_products():
     rows = cursor.fetchall()
     conn.close()
     return rows
+
+
+def get_plan_media(plan_name):
+    """Obtener información multimedia asociada a un plan"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT media_file_id, media_type, media_caption FROM subscription_products WHERE name = ?",
+        (plan_name,)
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row and row[0]:
+        return {'file_id': row[0], 'type': row[1], 'caption': row[2]}
+    return None
+
+
+def save_plan_media(plan_name, file_id, media_type, caption=None):
+    """Guardar multimedia para un plan"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE subscription_products SET media_file_id=?, media_type=?, media_caption=? WHERE name=?",
+            (file_id, media_type, caption, plan_name),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        return False
+    finally:
+        conn.close()
+
+
+def remove_plan_media(plan_name):
+    """Eliminar multimedia de un plan"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE subscription_products SET media_file_id=NULL, media_type=NULL, media_caption=NULL WHERE name=?",
+            (plan_name,),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        return False
+    finally:
+        conn.close()
+
+
+def has_plan_media(plan_name):
+    return get_plan_media(plan_name) is not None
+
+
+def get_plans_with_media():
+    """Listar planes con multimedia"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT name, media_type FROM subscription_products WHERE media_file_id IS NOT NULL"
+    )
+    rows = cur.fetchall()
+    conn.close()
+    return rows
+
+
+def get_plans_without_media():
+    """Listar planes sin multimedia"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT name FROM subscription_products WHERE media_file_id IS NULL"
+    )
+    rows = [r[0] for r in cur.fetchall()]
+    conn.close()
+    return rows
+
+
+def get_delivery_info(plan_id):
+    """Obtener información de entrega de un plan"""
+    plan = get_subscription_product(plan_id)
+    if not plan:
+        return None, None
+    delivery_format = plan[17] if len(plan) > 17 else 'none'
+    delivery_content = plan[18] if len(plan) > 18 else None
+    return delivery_format, delivery_content
+
+
+def set_delivery_info(plan_name, delivery_format, delivery_content):
+    """Actualizar información de entrega"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE subscription_products SET delivery_format=?, delivery_content=? WHERE name=?",
+            (delivery_format, delivery_content, plan_name),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        return False
+    finally:
+        conn.close()
+
+
+def get_additional_description(plan_name):
+    """Obtener descripción adicional de un plan"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT additional_description FROM subscription_products WHERE name=?",
+        (plan_name,),
+    )
+    row = cur.fetchone()
+    conn.close()
+    if row and row[0]:
+        return row[0]
+    return ""
+
+
+def set_additional_description(plan_name, desc):
+    """Actualizar descripción adicional de un plan"""
+    init_subscription_db()
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE subscription_products SET additional_description=? WHERE name=?",
+            (desc, plan_name),
+        )
+        conn.commit()
+        return True
+    except Exception:
+        return False
+    finally:
+        conn.close()
+
+
+def has_additional_description(plan_name):
+    desc = get_additional_description(plan_name)
+    return bool(desc and desc.strip())
+
+
+def format_plan_with_media(plan_id):
+    """Formatear información de un plan para mostrar al usuario"""
+    plan = get_subscription_product(plan_id)
+    if not plan:
+        return None
+    (
+        _pid,
+        name,
+        desc,
+        price,
+        currency,
+        duration,
+        unit,
+        *_rest,
+        additional_desc,
+        media_file_id,
+        media_type,
+        media_caption,
+        _delivery_format,
+        _delivery_content,
+    ) = plan
+    info = f"**{name}**\n\n{desc}\n\nPrecio: {price} {currency}\nDuración: {duration} {unit}"
+    if media_file_id:
+        media_types = {
+            'photo': '📸',
+            'video': '🎥',
+            'document': '📄',
+            'audio': '🎵',
+            'animation': '🎬',
+        }
+        info += f"\n{media_types.get(media_type, '📎')}"
+        if media_caption:
+            info += f" {media_caption}"
+    return info
+
+
+def format_plan_additional_info(plan_id):
+    plan = get_subscription_product(plan_id)
+    if not plan:
+        return None
+    additional_desc = plan[13] if len(plan) > 13 else ''
+    if not additional_desc:
+        return 'No hay información adicional disponible'
+    return additional_desc
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fix missing `subscriptions` import when creating plans
- extend subscription products with multimedia and extra fields
- deliver multimedia/text on subscription purchase
- show subscription media and extra info in catalog

## Testing
- `python -m py_compile adminka.py main.py payments.py subscriptions.py`

------
https://chatgpt.com/codex/tasks/task_e_6858b379a284832e809f39c1636ad118