### PR TITLE
Add pytest and sample test

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Para ejecutar el proceso diario de forma sencilla puedes programar `subscription
 python subscription_cron.py
 ```
 
+## Pruebas
+
+Para ejecutar las pruebas automatizadas instala las dependencias y luego ejecuta:
+
+```bash
+pytest
+```
+
 ## Licencia
 
 Este proyecto se distribuye sin una licencia explícita.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ python-dotenv
 paypalrestsdk
 python-binance
 requests
+
+pytest

--- a/test_bot.py
+++ b/test_bot.py
@@ -1,3 +1,6 @@
+import pytest
+pytest.skip("manual script not intended for pytest", allow_module_level=True)
+
 import telebot
 import config # Importa tu archivo config para obtener el token y admin_id
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,0 +1,36 @@
+import os
+import sqlite3
+import importlib
+import sys
+import types
+
+import files
+
+
+def test_init_subscription_db(tmp_path, monkeypatch):
+    # Prepare environment and dummy modules
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "dummy")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+
+    sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+    sys.modules.setdefault('telebot', types.SimpleNamespace(TeleBot=lambda *a, **k: None))
+
+    db_path = tmp_path / "main_data.db"
+    monkeypatch.setattr(files, "main_db", str(db_path))
+
+    subscriptions = importlib.import_module('subscriptions')
+    importlib.reload(subscriptions)
+
+    subscriptions.init_subscription_db()
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    tables = {row[0] for row in cursor.fetchall()}
+    assert 'subscription_products' in tables
+    assert 'user_subscriptions' in tables
+
+    cursor.execute("PRAGMA index_list('user_subscriptions')")
+    indexes = {row[1] for row in cursor.fetchall()}
+    assert 'idx_user_subscriptions_end_date' in indexes
+    conn.close()


### PR DESCRIPTION
## Summary
- add pytest dependency
- add instructions for running tests
- skip `test_bot.py` during pytest
- add basic unit test to ensure subscription tables are created

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a3a70b50832e900ddd6da3ba4f68