### PR TITLE
Load advertising token from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+TELEGRAM_ADMIN_ID=123456789
+# Token utilizado por advertising_cron.py
+# Puedes definir múltiples tokens separados por comas
+TELEGRAM_TOKEN=your_advertising_token
+WHATICKET_URL=https://tu-whaticket.com
+WHATICKET_TOKEN=tu_token_whaticket

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Tienda Telegram es un bot de Telegram para gestionar un pequeño catálogo de pr
 pip install -r requirements.txt
 ```
 
-4. Copia el archivo `.env.example` a `.env` (o crea uno nuevo) e incluye tu `TELEGRAM_BOT_TOKEN` y el `TELEGRAM_ADMIN_ID` que se usarán en `config.py`.
+4. Copia el archivo `.env.example` a `.env` (o crea uno nuevo) e incluye tu `TELEGRAM_BOT_TOKEN` y el `TELEGRAM_ADMIN_ID` que se usarán en `config.py`. Si utilizarás el sistema de publicidad configura también `TELEGRAM_TOKEN` con el token (o tokens separados por comas) que empleará `advertising_cron.py`.
 
 ## Uso
 

--- a/advertising_cron.py
+++ b/advertising_cron.py
@@ -6,13 +6,19 @@ from datetime import datetime
 from advertising_system.auto_sender import AutoSender
 
 def load_config():
+    tokens_env = os.getenv("TELEGRAM_TOKEN")
+    if tokens_env:
+        telegram_tokens = [t.strip() for t in tokens_env.split(',') if t.strip()]
+    else:
+        telegram_tokens = [
+            '8107512310:AAGPO-rwj48QwVM8uK41ndj8q4Cy0f5QMKk',
+        ]
+
     return {
         'db_path': 'data/db/main_data.db',
-        'telegram_tokens': [
-            '8107512310:AAGPO-rwj48QwVM8uK41ndj8q4Cy0f5QMKk',
-        ],
-        'whaticket_url': 'https://tu-whaticket.com',
-        'whaticket_token': 'tu_token_whaticket'
+        'telegram_tokens': telegram_tokens,
+        'whaticket_url': os.getenv('WHATICKET_URL', 'https://tu-whaticket.com'),
+        'whaticket_token': os.getenv('WHATICKET_TOKEN', 'tu_token_whaticket')
     }
 
 def is_running():


### PR DESCRIPTION
## Summary
- read advertising token from `TELEGRAM_TOKEN` env var in `advertising_cron.py`
- provide `.env.example` with new variable
- document the variable in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b2cc12e0832e80bf548785f0695d