### PR TITLE
Require TELEGRAM_TOKEN for advertising cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 TELEGRAM_BOT_TOKEN=your_bot_token_here
 TELEGRAM_ADMIN_ID=123456789
-# Token utilizado por advertising_cron.py
+# Token utilizado por advertising_cron.py (obligatorio)
 # Puedes definir múltiples tokens separados por comas
 TELEGRAM_TOKEN=your_advertising_token
 WHATICKET_URL=https://tu-whaticket.com

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ pip install -r requirements.txt
    archivo de ejemplo incluye los campos `TELEGRAM_BOT_TOKEN` y
    `TELEGRAM_ADMIN_ID` como referencia, así que sólo debes reemplazar sus
    valores con tus credenciales.  Si utilizarás el sistema de publicidad,
-   completa también `TELEGRAM_TOKEN` con el token (o los tokens separados
-   por comas) que empleará `advertising_cron.py`.
+   **debes** definir `TELEGRAM_TOKEN` con el token (o los tokens separados
+   por comas) que empleará `advertising_cron.py`; el script fallará si no
+   se configura esta variable.
 
 ## Uso
 
@@ -92,10 +93,10 @@ con comandos para gestionar campañas:
 - `⚙️ Configuración` para ajustes adicionales.
 - `▶️ Envío manual` para disparar un envío inmediato.
 
-Actualmente los tokens que usa el *AutoSender* se establecen directamente en
-`advertising_cron.py`. No se definen variables de entorno adicionales, pero
-puedes modificar el script para leer valores como `AUTOSENDER_TELEGRAM_TOKENS`
-si lo necesitas.
+`advertising_cron.py` obtiene los tokens a utilizar desde la variable de entorno
+`TELEGRAM_TOKEN`.  Puedes indicar varios tokens separados por comas si
+necesitas repartir la carga entre diferentes bots.  Si la variable no está
+definida el script terminará con un error.
 
 ## Pruebas
 

--- a/advertising_cron.py
+++ b/advertising_cron.py
@@ -7,12 +7,11 @@ from advertising_system.auto_sender import AutoSender
 
 def load_config():
     tokens_env = os.getenv("TELEGRAM_TOKEN")
-    if tokens_env:
-        telegram_tokens = [t.strip() for t in tokens_env.split(',') if t.strip()]
-    else:
-        telegram_tokens = [
-            '8107512310:AAGPO-rwj48QwVM8uK41ndj8q4Cy0f5QMKk',
-        ]
+    if not tokens_env:
+        raise SystemExit("TELEGRAM_TOKEN environment variable is required")
+    telegram_tokens = [t.strip() for t in tokens_env.split(',') if t.strip()]
+    if not telegram_tokens:
+        raise SystemExit("TELEGRAM_TOKEN is empty")
 
     return {
         'db_path': 'data/db/main_data.db',


### PR DESCRIPTION
## Summary
- remove hardcoded Telegram token from `advertising_cron.py`
- document that `TELEGRAM_TOKEN` must be set
- clarify marketing token docs and `.env.example`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f6e5b38c832ea3393cd369ca5d5f