### PR TITLE
Refactor bot initialization

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1,8 +1,8 @@
 import telebot, sqlite3, shelve, os
 import config, dop, files
 from advertising_system import AdvertisingManager
+from bot_instance import bot
 
-bot = telebot.TeleBot(config.token)
 advertising = AdvertisingManager(files.main_db)
 
 

--- a/adminka_minimal.py
+++ b/adminka_minimal.py
@@ -1,7 +1,6 @@
 import telebot, sqlite3, shelve, os
 import config, dop, files, subscriptions
-
-bot = telebot.TeleBot(config.token)
+from bot_instance import bot
 
 def in_adminka(chat_id, message_text, username, name_user):
     """Función principal de administración"""

--- a/bot_instance.py
+++ b/bot_instance.py
@@ -1,0 +1,2 @@
+import telebot, config
+bot = telebot.TeleBot(config.token)

--- a/dop.py
+++ b/dop.py
@@ -1,5 +1,6 @@
 import telebot, shelve, datetime, sqlite3, random, os
 import files, config
+from bot_instance import bot
 
 # ---------------------------------------------------------------------------
 # Utilidad para asegurar que la base de datos tenga las columnas necesarias
@@ -43,8 +44,6 @@ def ensure_database_schema():
 
 # Asegurar el esquema al importar el módulo
 ensure_database_schema()
-
-bot = telebot.TeleBot(config.token)
 
 # -------------------------------------------------
 # Utilidad para editar mensajes con o sin multimedia

--- a/install_improvements.py
+++ b/install_improvements.py
@@ -109,8 +109,7 @@ import telebot
 import files
 import config
 from datetime import datetime
-
-bot = telebot.TeleBot(config.token)
+from bot_instance import bot
 
 def validate_purchase_by_user(user_id=None, username=None):
     """Valida las compras de un usuario específico"""

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import telebot, shelve, sqlite3, os
 import config, dop, payments, adminka, files, subscriptions
+from bot_instance import bot
 import atexit
 import glob
 
@@ -25,7 +26,7 @@ if not os.path.exists('data/db/main_data.db'):
     print("❌ ERROR: Base de datos no encontrada. Ejecuta init_db.py primero.")
     exit(1)
 
-bot = telebot.TeleBot(config.token)
+
 in_admin = []
 
 @bot.message_handler(content_types=["text"])

--- a/payments.py
+++ b/payments.py
@@ -1,8 +1,7 @@
 import telebot, time, shelve, requests, json
 from datetime import datetime, timedelta
 import dop, config, files, subscriptions
-
-bot = telebot.TeleBot(config.token)
+from bot_instance import bot
 
 he_client = []
 pending_payments = {}  # Para almacenar pagos pendientes

--- a/purchase_validator.py
+++ b/purchase_validator.py
@@ -3,8 +3,7 @@ import telebot
 import files
 import config
 from datetime import datetime
-
-bot = telebot.TeleBot(config.token)
+from bot_instance import bot
 
 def validate_purchase_by_user(user_id=None, username=None):
     """Valida las compras de un usuario específico"""

--- a/subscriptions.py
+++ b/subscriptions.py
@@ -7,11 +7,11 @@ import telebot
 import config
 import dop
 import os
+from bot_instance import bot
 
 # Días de notificación por defecto (30, 15, 7 y 1 día antes)
 DEFAULT_NOTIFICATION_DAYS = '30,15,7,1'
 
-bot = telebot.TeleBot(config.token)
 
 # ---------------------------------------------------------------------------
 # Inicialización de base de datos


### PR DESCRIPTION
## Summary
- centralize Telegram bot creation in `bot_instance.py`
- use shared bot instance across modules
- update installer string for new import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca07b46088333a077290cbc250af3