### PR TITLE
Add optional polling env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ pip install -r requirements.txt
    por comas) que empleará `advertising_cron.py`; el script fallará si no
    se configura esta variable.
 
+   Puedes modificar la frecuencia de consulta al servidor de Telegram
+   estableciendo las variables opcionales `POLL_INTERVAL`, `POLL_TIMEOUT`
+   y `LONG_POLLING_TIMEOUT`.  Si no las defines, el bot utiliza los valores
+   por defecto `8`, `25` y `20` segundos respectivamente.
+
 ## Uso
 
 Antes de iniciar el bot por primera vez se debe crear la estructura de la base de datos. Ejecuta:

--- a/config.py
+++ b/config.py
@@ -8,6 +8,11 @@ load_dotenv()
 admin_id = int(os.getenv('TELEGRAM_ADMIN_ID', '723745098'))
 token = os.getenv('TELEGRAM_BOT_TOKEN')
 
+# Parámetros opcionales para telebot.polling
+POLL_INTERVAL = int(os.getenv('POLL_INTERVAL', '8'))
+POLL_TIMEOUT = int(os.getenv('POLL_TIMEOUT', '25'))
+LONG_POLLING_TIMEOUT = int(os.getenv('LONG_POLLING_TIMEOUT', '20'))
+
 # Verificar que el token esté configurado
 if not token:
     print("ERROR: No se encontró TELEGRAM_BOT_TOKEN en el archivo .env")

--- a/main.py
+++ b/main.py
@@ -456,10 +456,10 @@ def handle_media_files(message):
 
 if __name__ == '__main__':
     print("✅ Bot iniciando polling optimizado...")
-    # Polling optimizado para máximo rendimiento
+    # Polling optimizado configurable mediante variables de entorno
     bot.polling(
-        none_stop=True, 
-        interval=8,               # Reducido de 10 a 8 para mejor respuesta
-        timeout=25,               # Aumentado para mayor eficiencia
-        long_polling_timeout=20   # Optimizado
+        none_stop=True,
+        interval=config.POLL_INTERVAL,
+        timeout=config.POLL_TIMEOUT,
+        long_polling_timeout=config.LONG_POLLING_TIMEOUT
     )


### PR DESCRIPTION
## Summary
- allow configuring polling timings via `POLL_INTERVAL`, `POLL_TIMEOUT` and `LONG_POLLING_TIMEOUT` in `config.py`
- use these settings in `main.py` when starting `bot.polling`
- document the new environment variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca4ccb30c8333aee8bc52d1a80179