### PR TITLE
Improve auto sender timing

### DIFF
--- a/advertising_system/auto_sender.py
+++ b/advertising_system/auto_sender.py
@@ -56,14 +56,15 @@ class AutoSender:
     def _main_loop(self):
         while self.running:
             try:
-                self._check_and_send_campaigns()
-                time.sleep(30)
+                sent_any = self._check_and_send_campaigns()
+                time.sleep(30 if sent_any else 60)
             except Exception as e:
                 self.logger.error(f"Error en main loop: {e}")
                 time.sleep(60)
 
     def _check_and_send_campaigns(self):
         pending_sends = self.scheduler.get_pending_sends()
+        processed = False
         for send_data in pending_sends:
             schedule_id = send_data[0]
             campaign_id = send_data[1]
@@ -73,7 +74,9 @@ class AutoSender:
                     self._send_telegram_campaign(campaign_id, schedule_id, send_data)
                 elif platform == 'whatsapp':
                     self._send_whatsapp_campaign(campaign_id, schedule_id, send_data)
+                processed = True
                 time.sleep(2)
+        return processed
 
     def _get_telegram_groups(self):
         conn = sqlite3.connect(self.scheduler.db_path)

--- a/tests/test_auto_sender.py
+++ b/tests/test_auto_sender.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+
+
+def test_check_and_send_campaigns_returns_bool(tmp_path, monkeypatch):
+    # Reload the real module in case previous tests inserted a stub
+    sys.modules.pop('advertising_system.auto_sender', None)
+    auto_sender = importlib.import_module('advertising_system.auto_sender')
+    AutoSender = auto_sender.AutoSender
+
+    config = {
+        'db_path': str(tmp_path / 'db.db'),
+        'telegram_tokens': ['t'],
+        'whaticket_url': 'http://w',
+        'whaticket_token': 'tok'
+    }
+    sender = AutoSender(config)
+
+    # Avoid actual delays
+    monkeypatch.setattr(auto_sender.time, 'sleep', lambda x: None)
+
+    calls = []
+    monkeypatch.setattr(sender, '_send_telegram_campaign', lambda *a, **k: calls.append('tg'))
+    monkeypatch.setattr(sender, '_send_whatsapp_campaign', lambda *a, **k: calls.append('wa'))
+
+    sender.scheduler.get_pending_sends = lambda: [(1, 2, None, None, None, None, 'telegram')]
+    assert sender._check_and_send_campaigns() is True
+    assert calls == ['tg']
+
+    calls.clear()
+    sender.scheduler.get_pending_sends = lambda: []
+    assert sender._check_and_send_campaigns() is False
+    assert calls == []


### PR DESCRIPTION
## Summary
- extend AutoSender main loop to sleep longer when no campaigns are processed
- make `_check_and_send_campaigns` return a boolean
- test new boolean return from `_check_and_send_campaigns`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca5fdda248333866ec816f6461e1a