### PR TITLE
Add payment processing and autosender tests

### DIFF
--- a/tests/test_auto_sender.py
+++ b/tests/test_auto_sender.py
@@ -31,3 +31,55 @@ def test_check_and_send_campaigns_returns_bool(tmp_path, monkeypatch):
     sender.scheduler.get_pending_sends = lambda: []
     assert sender._check_and_send_campaigns() is False
     assert calls == []
+
+
+def test_check_and_send_campaigns_with_mocked_dependencies(monkeypatch):
+    sys.modules.pop('advertising_system.auto_sender', None)
+    auto_sender = importlib.import_module('advertising_system.auto_sender')
+
+    class DummyScheduler:
+        def __init__(self, db_path):
+            pass
+
+        def get_pending_sends(self):
+            return [(1, 2, None, None, None, None, 'telegram,whatsapp')]
+
+        def update_next_send(self, *a):
+            pass
+
+    class DummyRateLimiter:
+        def __init__(self, db_path):
+            pass
+
+    class DummyStats:
+        def __init__(self, db_path):
+            pass
+
+    monkeypatch.setattr(auto_sender, 'CampaignScheduler', DummyScheduler)
+    monkeypatch.setattr(auto_sender, 'IntelligentRateLimiter', DummyRateLimiter)
+    monkeypatch.setattr(auto_sender, 'StatisticsManager', DummyStats)
+    monkeypatch.setattr(auto_sender, 'TelegramMultiBot', lambda *a, **k: object())
+    monkeypatch.setattr(auto_sender, 'WHATicketAPI', lambda *a, **k: object())
+
+    AutoSender = auto_sender.AutoSender
+
+    config = {
+        'db_path': 'db',
+        'telegram_tokens': ['t'],
+        'whaticket_url': 'http://w',
+        'whaticket_token': 'tok'
+    }
+    sender = AutoSender(config)
+
+    monkeypatch.setattr(auto_sender.time, 'sleep', lambda x: None)
+    calls = []
+    monkeypatch.setattr(sender, '_send_telegram_campaign', lambda *a, **k: calls.append('tg'))
+    monkeypatch.setattr(sender, '_send_whatsapp_campaign', lambda *a, **k: calls.append('wa'))
+
+    assert sender._check_and_send_campaigns() is True
+    assert calls == ['tg', 'wa']
+
+    calls.clear()
+    sender.scheduler.get_pending_sends = lambda: []
+    assert sender._check_and_send_campaigns() is False
+    assert calls == []

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -1,0 +1,120 @@
+import importlib
+import sys
+import types
+import os
+import builtins
+from pathlib import Path
+
+
+def setup_payments(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+
+    sys.modules.setdefault(
+        "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+    )
+
+    telebot_stub = types.SimpleNamespace(
+        TeleBot=lambda *a, **k: types.SimpleNamespace(
+            send_message=lambda *a, **k: None,
+            answer_callback_query=lambda *a, **k: None,
+            edit_message_text=lambda *a, **k: None,
+            edit_message_caption=lambda *a, **k: None,
+            delete_message=lambda *a, **k: None,
+        ),
+        types=types.SimpleNamespace(
+            InlineKeyboardMarkup=lambda *a, **k: types.SimpleNamespace(
+                add=lambda *a, **k: None
+            ),
+            InlineKeyboardButton=lambda *a, **k: None,
+        ),
+    )
+    sys.modules["telebot"] = telebot_stub
+    bot_stub = telebot_stub.TeleBot()
+    sys.modules["bot_instance"] = types.SimpleNamespace(bot=bot_stub)
+    sys.modules.setdefault(
+        "requests", types.SimpleNamespace(post=lambda *a, **k: None, get=lambda *a, **k: None)
+    )
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    import files
+
+    monkeypatch.setattr(files, "main_db", str(tmp_path / "main.db"))
+
+    sys.modules.pop("payments", None)
+    payments = importlib.import_module("payments")
+
+    orig_open = builtins.open
+
+    def fake_open(file, mode="r", encoding=None):
+        if isinstance(file, str) and file.startswith("data/Temp/"):
+            real = tmp_path / file
+            real.parent.mkdir(parents=True, exist_ok=True)
+            return orig_open(real, mode, encoding=encoding)
+        return orig_open(file, mode, encoding=encoding)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    return payments, bot_stub
+
+
+def test_creat_bill_binance_records_payment(tmp_path, monkeypatch):
+    payments, _ = setup_payments(monkeypatch, tmp_path)
+    monkeypatch.setattr(payments.dop, "get_binancedata", lambda: ("a", "b", "ID"))
+
+    captured = {}
+
+    def dummy_edit(*a, **k):
+        captured["text"] = a[2]
+
+    monkeypatch.setattr(payments.dop, "safe_edit_message", dummy_edit)
+
+    payments.creat_bill_binance(5, "cb", 1, 4.5, "Prod", 1)
+
+    assert 5 in payments.pending_payments
+    info = payments.pending_payments[5]
+    assert info["product"] == "Prod"
+    assert info["quantity"] == 1
+    assert info["amount"] == 4.5
+    assert info["payment_id"].startswith("BIN_5_")
+    assert 5 in payments.he_client
+    assert captured["text"].startswith("💳")
+    assert (tmp_path / "data" / "Temp" / "5.txt").exists()
+
+
+def test_handle_admin_payment_decision_approves(tmp_path, monkeypatch):
+    payments, bot = setup_payments(monkeypatch, tmp_path)
+
+    delivered = {}
+
+    def deliver(*args):
+        delivered["args"] = args
+        return True
+
+    monkeypatch.setattr(payments, "deliver_product", deliver)
+    monkeypatch.setattr(payments.dop, "safe_edit_message", lambda *a, **k: None)
+
+    payments.pending_payments[123] = {
+        "payment_id": "PID",
+        "amount": 5,
+        "product": "Item",
+        "quantity": 1,
+        "timestamp": 0,
+    }
+    payments.he_client.append(123)
+
+    with builtins.open("data/Temp/123good_name.txt", "w", encoding="utf-8") as f:
+        f.write("Item")
+
+    calls = []
+    bot.send_message = lambda *a, **k: calls.append("send")
+    bot.answer_callback_query = lambda *a, **k: calls.append("answer")
+
+    payments.handle_admin_payment_decision("APROBAR_PAGO_123", 99, "cid", 1)
+
+    assert delivered["args"][0] == 123
+    assert 123 not in payments.pending_payments
+    assert 123 not in payments.he_client
+    assert "answer" in calls


### PR DESCRIPTION
## Summary
- test payments.creat_bill_binance and handle_admin_payment_decision with mocks
- mock AutoSender dependencies when testing _check_and_send_campaigns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ca77bb9688333a9e31b30817d5b8c