### PR TITLE
Show product duration

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -105,11 +105,19 @@ def in_adminka(chat_id, message_text, username, name_user):
             cursor = con.cursor()
             goodz = 'Productos creados:\n\n'
             a = 0
-            cursor.execute("SELECT name, description, format, minimum, price, stored FROM goods;") 
-            for name, description, format, minimum, price, stored in cursor.fetchall():
+            cursor.execute("SELECT name, description, format, minimum, price, stored, duration_days FROM goods;")
+            for name, description, format, minimum, price, stored, duration in cursor.fetchall():
                 a += 1
                 amount = dop.amount_of_goods(name)
-                goodz += '*Nombre:* ' + name + '\n*Descripción:* ' + description + '\n*Formato del producto:* ' + format + '\n*Cantidad mínima para comprar:* ' + str(minimum) + '\n*Precio por unidad:* $' + str(price) + ' USD' + '\n*Unidades restantes:* ' + str(amount) + '\n\n'
+                dur_line = f"\n*Duración:* {duration} días" if duration not in (None, 0) else ''
+                goodz += (
+                    '*Nombre:* ' + name + '\n*Descripción:* ' + description +
+                    '\n*Formato del producto:* ' + format +
+                    '\n*Cantidad mínima para comprar:* ' + str(minimum) +
+                    '\n*Precio por unidad:* $' + str(price) + ' USD' +
+                    dur_line +
+                    '\n*Unidades restantes:* ' + str(amount) + '\n\n'
+                )
             if a == 0: 
                 goodz = '¡No se han creado posiciones todavía!'
             bot.send_message(chat_id, goodz, reply_markup=user_markup, parse_mode='MarkDown')

--- a/dop.py
+++ b/dop.py
@@ -436,7 +436,7 @@ def get_description(name_good):
             product_description += f"💰 *Precio:* ${price} USD\n\n"
         
         product_description += f"📦 *Stock disponible:* {good_amount} unidades\n"
-        if duration:
+        if duration not in (None, 0):
             product_description += f"⏳ *Duración:* {duration} días\n"
         product_description += f"🛒 *Mínimo de compra:* {get_minimum(name_good)} unidades"
         
@@ -959,8 +959,9 @@ def format_product_basic_info(good_name):
 📋 **Formato:** {format_display}
 📊 **Disponibles:** {amount}"""
 
-        if product_info.get('duration_days'):
-            info_text += f"\n⏳ **Duración:** {product_info['duration_days']} días"
+        duration = product_info.get('duration_days')
+        if duration not in (None, 0):
+            info_text += f"\n⏳ **Duración:** {duration} días"
         
         return info_text
     except Exception as e:
@@ -1103,7 +1104,7 @@ def format_product_with_media(product_name):
         info = f"🎯 **{name}**\n"
         info += f"💰 **Precio:** ${price} USD\n"
         info += f"📝 **Descripción:** {description}\n"
-        if duration:
+        if duration not in (None, 0):
             info += f"⏳ **Duración:** {duration} días\n"
         
         if file_id:


### PR DESCRIPTION
## Summary
- append product duration when available in catalog listings
- include duration days in admin product overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce4b3df988333a9e0815fb517def0