### PR TITLE
Remove subscription tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ pip install -r requirements.txt
    y `LONG_POLLING_TIMEOUT`.  Si no las defines, el bot utiliza los valores
    por defecto `8`, `25` y `20` segundos respectivamente.
 
+### Actualización
+
+Si cuentas con una instalación previa y tu base de datos incluye las tablas
+`subscription_products` o `user_subscriptions`, ejecuta:
+
+```bash
+python migrate_drop_subscriptions.py
+```
+
+antes de iniciar la nueva versión del bot para eliminarlas de forma segura.
+
 ## Uso
 
 Antes de iniciar el bot por primera vez se debe crear la estructura de la base de datos. Ejecuta:

--- a/init_db.py
+++ b/init_db.py
@@ -81,43 +81,7 @@ def create_database():
     ''')
     print("✓ Tabla 'coinbase_data' creada")
 
-    # Tablas para sistema de suscripciones
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS subscription_products (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            name TEXT UNIQUE,
-            description TEXT,
-            price INTEGER,
-            currency TEXT DEFAULT 'USD',
-            duration INTEGER,
-            duration_unit TEXT DEFAULT 'days',
-            service_type TEXT,
-            status TEXT DEFAULT 'active',
-            grace_period INTEGER DEFAULT 0,
-            auto_renew INTEGER DEFAULT 1,
-            early_discount INTEGER DEFAULT 0,
-            notification_days TEXT DEFAULT '30,15,7,1'
-        )
-    ''')
-    print("✓ Tabla 'subscription_products' creada")
 
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS user_subscriptions (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            user_id INTEGER,
-            product_id INTEGER,
-            start_date TEXT,
-            end_date TEXT,
-            status TEXT DEFAULT 'active',
-            payment_method TEXT,
-            renewal_history TEXT
-        )
-    ''')
-    print("✓ Tabla 'user_subscriptions' creada")
-
-    cursor.execute('CREATE INDEX IF NOT EXISTS idx_user_subscriptions_end_date '
-                   'ON user_subscriptions(end_date)')
-    print("✓ Índice en 'user_subscriptions.end_date' creado")
 
     # Tablas para sistema de publicidad
     cursor.execute('''

--- a/migrate_drop_subscriptions.py
+++ b/migrate_drop_subscriptions.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Drop obsolete subscription tables from the database."""
+
+import sqlite3
+import db
+
+
+def main():
+    conn = db.get_db_connection()
+    cur = conn.cursor()
+
+    cur.execute("DROP TABLE IF EXISTS user_subscriptions")
+    cur.execute("DROP TABLE IF EXISTS subscription_products")
+
+    try:
+        cur.execute("DROP INDEX IF EXISTS idx_user_subscriptions_end_date")
+    except sqlite3.Error:
+        pass
+
+    conn.commit()
+    print("✓ Tablas de suscripciones eliminadas")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- remove subscription table creation from `init_db.py`
- add migration script to drop subscription tables
- document migration process in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce8e9e358833390166a1e3beb0045