### PR TITLE
Fix repeated menus during user navigation

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -63,23 +63,6 @@ def create_database():
     ''')
     print("✓ Tabla 'buyers' creada")
     
-    # Crear tabla de datos QIWI
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS qiwi_data (
-            number TEXT PRIMARY KEY,
-            token TEXT
-        )
-    ''')
-    print("✓ Tabla 'qiwi_data' creada")
-    
-    # Crear tabla de datos Coinbase
-    cursor.execute('''
-        CREATE TABLE IF NOT EXISTS coinbase_data (
-            api_key TEXT,
-            private_key TEXT
-        )
-    ''')
-    print("✓ Tabla 'coinbase_data' creada")
 
 
 
@@ -203,7 +186,7 @@ def create_database():
     print("\n🎉 ¡Base de datos y estructura creada exitosamente!")
     print("\nPróximos pasos:")
     print("1. Verifica que tu token en config.py sea correcto")
-    print("2. Instala las dependencias: pip install pyTelegramBotAPI SimpleQIWI coinbase")
+    print("2. Instala las dependencias: pip install pyTelegramBotAPI paypalrestsdk python-binance")
     print("3. Ejecuta: python main.py")
     print("4. Envía /start al bot para configuración inicial")
 

--- a/main.py
+++ b/main.py
@@ -229,7 +229,9 @@ def inline(callback):
                 catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog()}"
                 if callback.message.content_type != 'text':
                     bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
+                    bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
+                else:
+                    dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
 
         # Mostrar información del producto
         elif the_goods and callback.data in the_goods:
@@ -333,7 +335,9 @@ def inline(callback):
                     start_message = start_message.replace('name', callback.message.from_user.first_name)
                     if callback.message.content_type != 'text':
                         bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                    bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
+                        bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
+                    else:
+                        dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
 
         elif callback.data == 'Comprar':
             with open('data/Temp/' + str(callback.message.chat.id) + 'good_name.txt', encoding='utf-8') as f: 

--- a/payments.py
+++ b/payments.py
@@ -21,10 +21,6 @@ except ImportError:
     print("Advertencia: python-binance no instalado. Los pagos Binance no funcionarán.")
 
 def creat_bill_paypal(chat_id, callback_id, message_id, sum_amount, name_good, amount):
-    # PAYPAL DESHABILITADO TEMPORALMENTE
-    bot.answer_callback_query(callback_query_id=callback_id, show_alert=True, text="PayPal temporalmente deshabilitado")
-    return
-    # FIN DESHABILITACION
     """Crear factura PayPal - función sin cambios"""
     if not PAYPAL_AVAILABLE:
         bot.answer_callback_query(callback_query_id=callback_id, show_alert=True, text='PayPal no está disponible!')


### PR DESCRIPTION
## Summary
- clean up old menu messages when users navigate back to the catalog or start page
- enable PayPal payments and remove unused gateways

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc70bdf8483339a0adda6681b3f18