### PR TITLE
Fix broadcast skip for no media

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1200,19 +1200,17 @@ def text_analytics(message_text, chat_id):
                 in_adminka(chat_id, 'Volver al menú principal', None, None)
                 return
 
-            media = None
-            if message_text.lower() in ('no', 'skip', 'sin archivo'):
-                pass
+            if message_text.lower().strip() in ('no', 'skip', 'sin archivo'):
+                result = dop.broadcast_message(group, amount, text)
+                bot.send_message(chat_id, result)
+                try:
+                    os.remove('data/Temp/' + str(chat_id) + '.txt')
+                except Exception:
+                    pass
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
             else:
-                media = None
-            result = dop.broadcast_message(group, amount, text, media)
-            bot.send_message(chat_id, result)
-            try:
-                os.remove('data/Temp/' + str(chat_id) + '.txt')
-            except Exception:
-                pass
-            with shelve.open(files.sost_bd) as bd:
-                del bd[str(chat_id)]
+                bot.send_message(chat_id, 'Envía un archivo multimedia o escribe "no" para continuar sin archivo.')
 
 
 

--- a/main.py
+++ b/main.py
@@ -64,8 +64,6 @@ in_admin = []
 
 @bot.message_handler(content_types=["text"])
 def message_send(message):
-    # Permitir que adminka.py procese archivos multimedia cuando corresponde
-    adminka.handle_multimedia(message)
     
     if '/start' == message.text:
         if message.chat.username:


### PR DESCRIPTION
## Summary
- send broadcast immediately if admin types `no` in state 42
- don't process multimedia handler for normal text messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d66fae3388333bd46ba596c4998e8