### PR TITLE
Fix PayPal setup message

### DIFF
--- a/config_paypal_simple.py
+++ b/config_paypal_simple.py
@@ -24,7 +24,7 @@ def config_paypal():
         conn.close()
         
         print("GUARDADO!")
-        print("Ahora ejecuta: python3 reactivar_paypal.py")
+        print("Ahora ejecuta: python3 reactivar_paypal_simple.py")
         
     except Exception as e:
         print(f"ERROR: {e}")


### PR DESCRIPTION
## Summary
- reference the right script name in `config_paypal_simple.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d70ffb5a08333b6594c343cf3417b