### PR TITLE
Add manual delivery option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start
 ## Panel de administración
 
 Al entrar verás botones para gestionar las distintas funciones del bot. Entre
-ellos se incluyen **💬 Respuestas**, **📦 Surtido**, **➕ Producto**, **💰 Pagos**, 
+ellos se incluyen **💬 Respuestas**, **📦 Surtido**, **➕ Producto**, **💰 Pagos**,
 **📊 Stats**, **📣 Difusión**, **📢 Marketing**, **💸 Descuentos** y **⚙️ Otros**.
+
+En **💬 Respuestas** puedes definir distintos textos que el bot enviará. Se añadió la opción
+**Agregar/Cambiar mensaje de entrega manual**, utilizado cuando un producto requiere
+entrega manual. En ese mensaje puedes incluir las palabras `username` y `name` para
+personalizarlo.
 
 ### Carga y edición de unidades
 
@@ -76,6 +81,10 @@ aparecen tres opciones:
 - **Eliminar unidades** – borra las líneas seleccionadas.
 
 Después de cada acción se vuelve al menú de productos.
+
+Al crear una nueva posición se preguntará ahora **¿Entrega manual?**. Si respondes
+*Sí*, el bot omitirá el formato del producto y utilizará el mensaje configurado
+anteriormente para avisar al comprador.
 
 ### Difusión
 

--- a/adminka.py
+++ b/adminka.py
@@ -101,10 +101,11 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row(start + ' bienvenida al usuario')
             user_markup.row(after_buy + ' mensaje después de pagar el producto')
             user_markup.row(help + ' respuesta al comando help', userfalse + ' mensaje si no hay nombre de usuario')
+            user_markup.row('Agregar/Cambiar mensaje de entrega manual')
             user_markup.row('Volver al menú principal')
             bot.send_message(chat_id, 'Seleccione qué mensaje desea cambiar.\nDespués de seleccionar, recibirá una breve instrucción', reply_markup=user_markup)
 
-        elif ' bienvenida al usuario' in message_text or ' mensaje después de pagar el producto' in message_text or ' respuesta al comando help' in message_text or ' mensaje si no hay nombre de usuario' in message_text:
+        elif ' bienvenida al usuario' in message_text or ' mensaje después de pagar el producto' in message_text or ' respuesta al comando help' in message_text or ' mensaje si no hay nombre de usuario' in message_text or 'mensaje de entrega manual' in message_text:
             key = telebot.types.InlineKeyboardMarkup()
             key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
             if ' bienvenida al usuario' in message_text: 
@@ -119,6 +120,9 @@ def in_adminka(chat_id, message_text, username, name_user):
             elif ' mensaje si no hay nombre de usuario' in message_text:
                 bot.send_message(chat_id, '¡Ingrese un nuevo mensaje que se enviará si el usuario no tiene `username`! En el texto puede usar `uname`. Se reemplazará automáticamente por el nombre de usuario', parse_mode='MarkDown', reply_markup=key)
                 message = 'userfalse'
+            elif 'mensaje de entrega manual' in message_text:
+                bot.send_message(chat_id, 'Ingrese el mensaje que recibirá el comprador para productos de entrega manual. Puede usar `username` y `name`.', parse_mode='MarkDown', reply_markup=key)
+                message = 'manual_delivery'
             with open('data/Temp/' + str(chat_id) + '.txt', 'w', encoding ='utf-8') as f: 
                 f.write(message)
             with shelve.open(files.sost_bd) as bd : 
@@ -602,12 +606,15 @@ def text_analytics(message_text, chat_id):
             except FileNotFoundError:
                 session_expired(chat_id)
                 return
-            try:
-                with shelve.open(files.bot_message_bd) as bd:
-                    bd[message] = message_text
-                success = True
-            except:
-                success = False
+            if message == 'manual_delivery':
+                success = dop.save_message('manual_delivery', message_text)
+            else:
+                try:
+                    with shelve.open(files.bot_message_bd) as bd:
+                        bd[message] = message_text
+                    success = True
+                except:
+                    success = False
             if success:
                 user_markup = telebot.types.ReplyKeyboardMarkup(True, True)
                 user_markup.row('💬 Respuestas')
@@ -632,14 +639,34 @@ def text_analytics(message_text, chat_id):
                 bd[str(chat_id)] = 3
 
         elif sost_num == 3:
-            with open('data/Temp/' + str(chat_id) + 'good_description.txt', 'w', encoding='utf-8') as f: 
+            with open('data/Temp/' + str(chat_id) + 'good_description.txt', 'w', encoding='utf-8') as f:
                 f.write(message_text)
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
-            user_markup.row('En formato de texto', 'En formato de archivo')
+            user_markup.row('Sí', 'No')
             user_markup.row('Volver al menú principal')
-            bot.send_message(chat_id, 'Ahora seleccione el formato del producto', reply_markup=user_markup)
+            bot.send_message(chat_id, '¿Entrega manual?', reply_markup=user_markup)
             with shelve.open(files.sost_bd) as bd:
-                bd[str(chat_id)] = 4
+                bd[str(chat_id)] = 11
+
+        elif sost_num == 11:
+            manual_flag = '1' if message_text == 'Sí' else '0'
+            with open('data/Temp/' + str(chat_id) + 'good_manual.txt', 'w', encoding='utf-8') as f:
+                f.write(manual_flag)
+            if manual_flag == '1':
+                with open('data/Temp/' + str(chat_id) + 'good_format.txt', 'w', encoding='utf-8') as f2:
+                    f2.write('manual')
+                key = telebot.types.InlineKeyboardMarkup()
+                key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
+                bot.send_message(chat_id, 'Ahora ingrese la cantidad mínima para comprar', reply_markup=key)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 5
+            else:
+                user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                user_markup.row('En formato de texto', 'En formato de archivo')
+                user_markup.row('Volver al menú principal')
+                bot.send_message(chat_id, 'Ahora seleccione el formato del producto', reply_markup=user_markup)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 4
 
         elif sost_num == 4:
             format_map = {
@@ -707,6 +734,8 @@ def text_analytics(message_text, chat_id):
                 with open('data/Temp/' + str(chat_id) + 'good_format.txt', encoding='utf-8') as f:
                     format_type = f.read()
                 format_display = 'Texto' if format_type == 'text' else 'Archivo'
+                with open('data/Temp/' + str(chat_id) + 'good_manual.txt', encoding='utf-8') as f:
+                    manual_flag = f.read().strip()
                 with open('data/Temp/' + str(chat_id) + 'good_minimum.txt', encoding='utf-8') as f:
                     minimum = f.read()
                 with open('data/Temp/' + str(chat_id) + 'good_price.txt', encoding='utf-8') as f:
@@ -718,9 +747,11 @@ def text_analytics(message_text, chat_id):
             if duration_val > 0:
                 duration_display = f'\n*Duración:* {duration_val} días'
 
+            manual_text = 'Sí' if manual_flag == '1' else 'No'
             summary = (
                 f'*Resumen del producto:*\n\n*Nombre:* {name}\n*Descripción:* {description}'
                 f'\n*Formato:* {format_display}\n*Cantidad mínima:* {minimum}\n*Precio:* ${price} USD{duration_display}'
+                f'\n*Entrega manual:* {manual_text}'
             )
 
             media_temp = 'data/Temp/' + str(chat_id) + 'new_media.txt'
@@ -1440,6 +1471,8 @@ def ad_inline(callback_data, chat_id, message_id):
                 description = f.read()
             with open('data/Temp/' + str(chat_id) + 'good_format.txt', encoding='utf-8') as f:
                 format_type = f.read()
+            with open('data/Temp/' + str(chat_id) + 'good_manual.txt', encoding='utf-8') as f:
+                manual_flag = f.read().strip()
             with open('data/Temp/' + str(chat_id) + 'good_minimum.txt', encoding='utf-8') as f:
                 minimum = f.read()
             with open('data/Temp/' + str(chat_id) + 'good_price.txt', encoding='utf-8') as f:
@@ -1469,10 +1502,12 @@ def ad_inline(callback_data, chat_id, message_id):
                     media_type = lines[1]
                     media_caption = lines[2] if len(lines) > 2 else None
 
+        if manual_flag == '1':
+            format_type = 'manual'
         cursor.execute(
             """
-            INSERT INTO goods (name, description, format, minimum, price, stored, additional_description, media_file_id, media_type, media_caption, duration_days)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO goods (name, description, format, minimum, price, stored, additional_description, media_file_id, media_type, media_caption, duration_days, manual_delivery)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name,
@@ -1486,6 +1521,7 @@ def ad_inline(callback_data, chat_id, message_id):
                 media_type,
                 media_caption,
                 duration_days,
+                int(manual_flag),
             ),
         )
         con.commit()

--- a/dop.py
+++ b/dop.py
@@ -35,6 +35,9 @@ def ensure_database_schema():
         if 'duration_days' not in columns:
             cursor.execute("ALTER TABLE goods ADD COLUMN duration_days INTEGER DEFAULT NULL")
             updated = True
+        if 'manual_delivery' not in columns:
+            cursor.execute("ALTER TABLE goods ADD COLUMN manual_delivery INTEGER DEFAULT 0")
+            updated = True
 
         if updated:
             con.commit()
@@ -221,14 +224,16 @@ def get_stored(name_good):
         return None
 
 def amount_of_goods(name_good):
+    if is_manual_delivery(name_good):
+        return 10 ** 9
     stored = get_stored(name_good)
     if not stored:
         return 0
-    try: 
-        with open(stored, encoding='utf-8') as f: 
+    try:
+        with open(stored, encoding='utf-8') as f:
             lines = f.readlines()
             return len([line for line in lines if line.strip()])
-    except: 
+    except:
         return 0
 
 def get_minimum(name_good):
@@ -979,19 +984,41 @@ def set_duration_days(product_name, days):
         print(f"Error estableciendo duración: {e}")
         return False
 
+def is_manual_delivery(product_name):
+    """Indica si un producto requiere entrega manual."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("SELECT manual_delivery FROM goods WHERE name = ?", (product_name,))
+        result = cursor.fetchone()
+        return bool(result and result[0])
+    except Exception as e:
+        print(f"Error comprobando entrega manual: {e}")
+        return False
+
+def get_manual_delivery_message(username, name):
+    """Obtiene el mensaje de entrega manual personalizado."""
+    try:
+        with shelve.open(files.bot_message_bd) as bd:
+            text = bd.get('manual_delivery', 'Gracias por su compra, username')
+    except Exception:
+        text = 'Gracias por su compra, username'
+    text = text.replace('username', username).replace('name', name)
+    return text
+
 def get_product_full_info(good_name):
     """Obtiene toda la información del producto incluyendo descripción adicional"""
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
         cursor.execute("""
-            SELECT name, description, additional_description, format, minimum, price, duration_days
+            SELECT name, description, additional_description, format, minimum, price, duration_days, manual_delivery
             FROM goods WHERE name = ?
         """, (good_name,))
         result = cursor.fetchone()
 
         if result:
-            name, description, additional_desc, format, minimum, price, duration_days = result
+            name, description, additional_desc, format, minimum, price, duration_days, manual = result
             return {
                 'name': name,
                 'description': description,
@@ -999,7 +1026,8 @@ def get_product_full_info(good_name):
                 'format': format,
                 'minimum': minimum,
                 'price': price,
-                'duration_days': duration_days
+                'duration_days': duration_days,
+                'manual_delivery': bool(manual)
             }
         else:
             return None
@@ -1014,7 +1042,7 @@ def format_product_basic_info(good_name):
         if not product_info:
             return "Producto no encontrado"
         
-        amount = amount_of_goods(good_name)  # Usar función existente
+        amount = amount_of_goods(good_name)
         
         format_map = {'text': 'Texto', 'file': 'Archivo'}
         format_display = format_map.get(product_info['format'], product_info['format'])
@@ -1026,8 +1054,12 @@ def format_product_basic_info(good_name):
 
 💰 **Precio:** ${product_info['price']} USD
 📦 **Cantidad mínima:** {product_info['minimum']}
-📋 **Formato:** {format_display}
-📊 **Disponibles:** {amount}"""
+📋 **Formato:** {format_display}"""
+
+        if product_info.get('manual_delivery'):
+            info_text += "\n🚚 **Entrega manual**"
+        else:
+            info_text += f"\n📊 **Disponibles:** {amount}"
 
         duration = product_info.get('duration_days')
         if duration not in (None, 0):
@@ -1160,7 +1192,7 @@ def format_product_with_media(product_name):
         con = db.get_db_connection()
         cursor = con.cursor()
         cursor.execute("""
-            SELECT name, description, price, media_file_id, media_type, media_caption, duration_days
+            SELECT name, description, price, media_file_id, media_type, media_caption, duration_days, manual_delivery
             FROM goods
             WHERE name = ?
         """, (product_name,))
@@ -1169,14 +1201,17 @@ def format_product_with_media(product_name):
         if not result:
             return None
             
-        name, description, price, file_id, media_type, caption, duration = result
+        name, description, price, file_id, media_type, caption, duration, manual = result
         
         info = f"🎯 **{name}**\n"
         info += f"💰 **Precio:** ${price} USD\n"
         info += f"📝 **Descripción:** {description}\n"
         if duration not in (None, 0):
             info += f"⏳ **Duración:** {duration} días\n"
-        
+
+        if manual:
+            info += "🚚 **Entrega manual**\n"
+
         if file_id:
             media_types = {
                 'photo': '📸 Imagen',

--- a/init_db.py
+++ b/init_db.py
@@ -36,7 +36,8 @@ def create_database():
             media_file_id TEXT,
             media_type TEXT,
             media_caption TEXT,
-            duration_days INTEGER DEFAULT NULL
+            duration_days INTEGER DEFAULT NULL,
+            manual_delivery INTEGER DEFAULT 0
         )
     ''')
     print("✓ Tabla 'goods' creada")

--- a/payments.py
+++ b/payments.py
@@ -450,24 +450,28 @@ def deliver_product(chat_id, username, first_name, name_good, amount, sum_amount
     try:
         print(f"DEBUG: Entregando producto {name_good} a usuario {chat_id}")
 
-        # Entregar producto físico/digital
-        text = ''
-        for i in range(int(amount)):
-            if dop.get_goodformat(name_good) == 'file':
-                product_data = dop.get_tovar(name_good)
-                if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
-                    bot.send_document(chat_id, product_data)
-                else:
-                    bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
-            elif dop.get_goodformat(name_good) == 'text':
-                product_data = dop.get_tovar(name_good)
-                if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
-                    text += product_data + '\n'
-                else:
-                    bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
+        if dop.is_manual_delivery(name_good):
+            manual_msg = dop.get_manual_delivery_message(username, first_name)
+            bot.send_message(chat_id, manual_msg)
+        else:
+            # Entregar producto físico/digital
+            text = ''
+            for i in range(int(amount)):
+                if dop.get_goodformat(name_good) == 'file':
+                    product_data = dop.get_tovar(name_good)
+                    if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
+                        bot.send_document(chat_id, product_data)
+                    else:
+                        bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
+                elif dop.get_goodformat(name_good) == 'text':
+                    product_data = dop.get_tovar(name_good)
+                    if product_data != "Error obteniendo producto" and product_data != "Producto agotado":
+                        text += product_data + '\n'
+                    else:
+                        bot.send_message(chat_id, f"❌ Error obteniendo {name_good}: {product_data}")
 
-        if dop.get_goodformat(name_good) == 'text' and text.strip():
-            bot.send_message(chat_id, text)
+            if dop.get_goodformat(name_good) == 'text' and text.strip():
+                bot.send_message(chat_id, text)
         
         # Mensaje después de compra
         if dop.check_message('after_buy') is True:


### PR DESCRIPTION
## Summary
- allow manual delivery products via new `manual_delivery` column
- extend admin menu to configure manual delivery message
- update product creation flow to ask for manual delivery
- support manual delivery in summaries and purchase flow
- document manual delivery configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8631e6848333abdc05ebed361681