### PR TITLE
Show stock overview when adding products

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -353,6 +353,12 @@ def in_adminka(chat_id, message_text, username, name_user):
 
 
         elif '➕ Producto' == message_text:
+            overview_lines = dop.get_stock_overview()
+            if overview_lines:
+                step = 10
+                for i in range(0, len(overview_lines), step):
+                    part = '\n'.join(overview_lines[i:i + step])
+                    bot.send_message(chat_id, part, parse_mode='Markdown')
             show_product_menu(chat_id)
 
         elif '💰 Pagos' == message_text:

--- a/dop.py
+++ b/dop.py
@@ -236,6 +236,24 @@ def amount_of_goods(name_good):
     except:
         return 0
 
+def get_stock_overview():
+    """Return a list with stock summary lines for all products."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("SELECT name, price FROM goods;")
+        goods = cursor.fetchall()
+
+        overview = []
+        for i, (name, price) in enumerate(goods, start=1):
+            count = amount_of_goods(name)
+            overview.append(f"{i}. {name} — {count} unidades (${price} USD)")
+
+        return overview
+    except Exception as e:
+        print(f"Error generando resumen de stock: {e}")
+        return []
+
 def get_minimum(name_good):
     try:
         con = db.get_db_connection()


### PR DESCRIPTION
## Summary
- add `get_stock_overview()` helper in `dop.py`
- display stock overview before showing the product menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d88005a5483338794fc403bcfbd97