### PR TITLE
Add admin integration helpers

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1,10 +1,13 @@
 import telebot, sqlite3, shelve, os
 import config, dop, files
 import db
-from advertising_system import AdvertisingManager
+from advertising_system.admin_integration import (
+    manager as advertising,
+    create_campaign_from_admin,
+    list_campaigns_for_admin,
+    add_target_group_from_admin,
+)
 from bot_instance import bot
-
-advertising = AdvertisingManager(files.main_db)
 
 
 def session_expired(chat_id):
@@ -415,13 +418,7 @@ def in_adminka(chat_id, message_text, username, name_user):
                 bd[str(chat_id)] = 160
 
         elif '📋 Ver campañas' == message_text:
-            campaigns = advertising.get_all_campaigns()
-            if campaigns:
-                response = '📋 *Campañas registradas:*\n'
-                for c in campaigns:
-                    response += f"- {c['id']}. {c['name']} ({c['status']})\n"
-            else:
-                response = 'ℹ️ No hay campañas registradas.'
+            response = list_campaigns_for_admin()
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
             user_markup.row('📢 Marketing')
             user_markup.row('Volver al menú principal')
@@ -1346,8 +1343,11 @@ def text_analytics(message_text, chat_id):
                 'button1_url': button1_url,
                 'created_by': chat_id,
             }
-            camp_id = advertising.create_campaign(data)
-            bot.send_message(chat_id, f'✅ Campaña creada con ID {camp_id}')
+            ok, msg = create_campaign_from_admin(data)
+            if ok:
+                bot.send_message(chat_id, '✅ ' + msg)
+            else:
+                bot.send_message(chat_id, '❌ ' + msg)
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
 
@@ -1385,7 +1385,7 @@ def text_analytics(message_text, chat_id):
                 session_expired(chat_id)
                 return
             name = None if message_text.lower() == 'no' else message_text
-            ok, msg = advertising.add_target_group(platform, gid, name)
+            ok, msg = add_target_group_from_admin(platform, gid, name)
             bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]

--- a/advertising_system/admin_integration.py
+++ b/advertising_system/admin_integration.py
@@ -1,5 +1,52 @@
-"""Funciones para integrar con adminka.py"""
+"""Funciones auxiliares para la integración con :mod:`adminka.py`."""
+
 from .ad_manager import AdvertisingManager
 from .statistics import StatisticsManager
+import files
 
-# Este módulo puede extenderse según sea necesario
+# Instancia única usada por los helpers de este módulo
+_manager = AdvertisingManager(files.main_db)
+
+# Reexportamos la instancia por si otros módulos necesitan acceso directo
+manager = _manager
+
+
+def create_campaign_from_admin(data):
+    """Crear una campaña mostrando un mensaje apto para la interfaz admin."""
+
+    try:
+        campaign_id = _manager.create_campaign(data)
+        return True, f"Campaña creada con ID {campaign_id}"
+    except Exception as exc:
+        return False, f"Error al crear campaña: {exc}"
+
+
+def list_campaigns_for_admin():
+    """Devolver un resumen de campañas para mostrar en el panel de admin."""
+
+    try:
+        campaigns = _manager.get_all_campaigns()
+    except Exception as exc:
+        return f"Error al obtener campañas: {exc}"
+
+    if not campaigns:
+        return "ℹ️ No hay campañas registradas."
+
+    lines = ["📋 *Campañas registradas:*"]
+    for camp in campaigns:
+        lines.append(f"- {camp['id']}. {camp['name']} ({camp['status']})")
+    return "\n".join(lines)
+
+
+def add_target_group_from_admin(platform, group_id, name=None):
+    """Registrar un grupo objetivo y devolver un mensaje para el admin."""
+
+    try:
+        ok, msg = _manager.add_target_group(platform, group_id, name)
+        return ok, msg
+    except Exception as exc:
+        return False, f"Error al agregar grupo: {exc}"
+
+
+# Las funciones existentes en AdvertisingManager se siguen exponiendo si se
+# requieren importarlas directamente desde adminka.py.


### PR DESCRIPTION
## Summary
- extend advertising integration with helper functions for adminka
- switch adminka to use the new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8f8a535c833390747b35024b504e