### PR TITLE
Extend content validation features

### DIFF
--- a/advertising_system/content_validator.py
+++ b/advertising_system/content_validator.py
@@ -1,8 +1,44 @@
+import re
+from urllib.parse import urlparse
+
+
 class ContentValidator:
-    """Simple validator to avoid spam"""
-    forbidden = ['spam', 'scam']
+    """Simple validator to avoid spam and unwanted content."""
+
+    #: Words that immediately mark the text as spam
+    forbidden = ["spam", "scam"]
+
+    #: Maximum length of an allowed text
+    max_length = 1000
+
+    #: Domains that are not allowed to appear in URLs
+    blacklisted_domains = set()
+
+    @staticmethod
+    def _strip_markup(text: str) -> str:
+        """Remove simple markdown and HTML tags from *text*."""
+        text = re.sub(r"<[^>]+>", "", text)
+        text = re.sub(r"[`*_]", "", text)
+        text = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", text)
+        return text
 
     @classmethod
-    def is_valid(cls, text):
+    def is_valid(cls, text: str, strip_markup: bool = False) -> bool:
+        """Return ``True`` if *text* passes validation checks."""
+
+        if strip_markup:
+            text = cls._strip_markup(text)
+
+        if len(text) > cls.max_length:
+            return False
+
         lower = text.lower()
-        return not any(word in lower for word in cls.forbidden)
+        if any(word in lower for word in cls.forbidden):
+            return False
+
+        for url in re.findall(r"https?://[^\s]+", text):
+            domain = urlparse(url).netloc.split(":")[0].lower()
+            if domain in cls.blacklisted_domains:
+                return False
+
+        return True

--- a/tests/test_content_validator.py
+++ b/tests/test_content_validator.py
@@ -1,0 +1,27 @@
+import pytest
+from advertising_system.content_validator import ContentValidator
+
+
+def test_rejects_forbidden_word():
+    assert not ContentValidator.is_valid("This is spam")
+
+
+def test_length_limit(monkeypatch):
+    monkeypatch.setattr(ContentValidator, "max_length", 5)
+    assert not ContentValidator.is_valid("123456")
+
+
+def test_blacklisted_domain(monkeypatch):
+    monkeypatch.setattr(ContentValidator, "blacklisted_domains", {"bad.com"})
+    assert not ContentValidator.is_valid("Visit http://bad.com")
+
+
+def test_strip_markup_allows_text():
+    assert ContentValidator.is_valid("<b>Hello</b>", strip_markup=True)
+
+
+def test_valid_text(monkeypatch):
+    monkeypatch.setattr(ContentValidator, "max_length", 1000)
+    monkeypatch.setattr(ContentValidator, "blacklisted_domains", set())
+    assert ContentValidator.is_valid("Check https://example.com")
+


### PR DESCRIPTION
## Summary
- expand validation logic for advertising content
- limit text length, filter markup, and block certain domains
- test various content validator scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d912f0eb08333a2be58da815ea8b2