### PR TITLE
Add JSON-based scheduling

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -458,16 +458,17 @@ def in_adminka(chat_id, message_text, username, name_user):
         elif message_text.startswith('⏰ Programar envíos'):
             params = message_text.replace('⏰ Programar envíos', '').strip()
             if not params:
-                bot.send_message(chat_id, 'Uso: ⏰ Programar envíos <ID> <HH:MM>')
+                bot.send_message(chat_id, 'Uso: ⏰ Programar envíos <ID> <dias> <HH:MM> <HH:MM>')
             else:
                 parts = params.split()
-                if len(parts) < 2:
-                    bot.send_message(chat_id, 'Uso: ⏰ Programar envíos <ID> <HH:MM>')
+                if len(parts) < 4:
+                    bot.send_message(chat_id, 'Uso: ⏰ Programar envíos <ID> <dias> <HH:MM> <HH:MM>')
                 else:
                     try:
                         camp_id = int(parts[0])
-                        time_str = parts[1]
-                        ok, msg = advertising.schedule_campaign(camp_id, time_str)
+                        days = parts[1].split(',')
+                        times = parts[2:4]
+                        ok, msg = advertising.schedule_campaign(camp_id, days, times)
                         bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
                     except ValueError:
                         bot.send_message(chat_id, '❌ ID de campaña inválido')

--- a/advertising_system/ad_manager.py
+++ b/advertising_system/ad_manager.py
@@ -1,5 +1,6 @@
 import sqlite3
 import re
+import json
 from datetime import datetime
 from .campaign_database import CampaignDB
 from .scheduler import CampaignScheduler
@@ -90,13 +91,22 @@ class AdvertisingManager:
             'groups': groups
         }
 
-    def schedule_campaign(self, campaign_id, send_time, platforms=None):
-        """Programar una campaña para enviarse a una hora específica."""
+    def schedule_campaign(self, campaign_id, days, times, platforms=None):
+        """Programar una campaña para enviarse en días y horas específicas."""
         if platforms is None:
             platforms = ['telegram']
 
-        if not re.match(r'^\d{2}:\d{2}$', send_time):
-            return False, 'Formato de hora inválido'
+        valid_days = {'lunes','martes','miercoles','jueves','viernes','sabado','domingo'}
+        day_list = [d.strip().lower() for d in days]
+        if any(d not in valid_days for d in day_list):
+            return False, 'Día inválido'
+
+        for t in times:
+            if not re.match(r'^\d{2}:\d{2}$', t):
+                return False, 'Formato de hora inválido'
+
+        schedule = {d: times[:2] for d in day_list}
+        schedule_json = json.dumps(schedule)
 
         conn, shared = self._get_connection()
         cur = conn.cursor()
@@ -109,14 +119,14 @@ class AdvertisingManager:
         try:
             cur.execute(
                 """INSERT INTO campaign_schedules
-                   (campaign_id, schedule_name, frequency, send_times,
+                   (campaign_id, schedule_name, frequency, schedule_json,
                     target_platforms, created_date)
                    VALUES (?, ?, ?, ?, ?, ?)""",
                 (
                     campaign_id,
                     'manual',
-                    'once',
-                    send_time,
+                    'weekly',
+                    schedule_json,
                     ','.join(platforms),
                     datetime.now().isoformat(),
                 ),

--- a/advertising_system/scheduler.py
+++ b/advertising_system/scheduler.py
@@ -1,4 +1,5 @@
 import sqlite3
+import json
 from datetime import datetime, timedelta
 import files
 import db
@@ -38,7 +39,7 @@ class CampaignScheduler:
                 schedule_data = {
                     'campaign_id': campaign_id,
                     'platform': platform,
-                    'send_time': send_time,
+                    'schedule_json': json.dumps({d: [send_time] for d in ['lunes','martes','miercoles','jueves','viernes','sabado','domingo']}),
                     'group_range': f'{start_groups}-{end_groups}',
                     'estimated_duration': estimated_duration
                 }
@@ -52,10 +53,10 @@ class CampaignScheduler:
         cursor = conn.cursor()
         cursor.execute(
             """INSERT INTO campaign_schedules
-               (campaign_id, schedule_name, frequency, send_times, target_platforms, created_date)
+               (campaign_id, schedule_name, frequency, schedule_json, target_platforms, created_date)
                VALUES (?, ?, ?, ?, ?, ?)""",
             (
-                data['campaign_id'], 'auto', 'daily', data['send_time'], data['platform'], datetime.now().isoformat()
+                data['campaign_id'], 'auto', 'daily', data['schedule_json'], data['platform'], datetime.now().isoformat()
             )
         )
         conn.commit()
@@ -72,14 +73,23 @@ class CampaignScheduler:
                    c.button1_text, c.button1_url, c.button2_text, c.button2_url
                FROM campaign_schedules cs
                JOIN campaigns c ON cs.campaign_id = c.id
-               WHERE cs.is_active = 1 AND c.status = 'active' AND cs.send_times LIKE ?""",
-            (f'%{current_time}%',)
+               WHERE cs.is_active = 1 AND c.status = 'active'"""
         )
-        pending = cursor.fetchall()
+        rows = cursor.fetchall()
+        pending = []
+        day_map = ['lunes', 'martes', 'miercoles', 'jueves', 'viernes', 'sabado', 'domingo']
+        today = day_map[now.weekday()]
+        for row in rows:
+            try:
+                schedule = json.loads(row[4] or '{}')
+            except Exception:
+                continue
+            if current_time in schedule.get(today, []):
+                pending.append(row)
+
         if not shared:
             conn.close()
         return pending
-
     def update_next_send(self, schedule_id, platform):
         next_send = datetime.now() + timedelta(days=1)
         conn, shared = self._get_connection()

--- a/init_db.py
+++ b/init_db.py
@@ -93,7 +93,7 @@ def create_database():
             campaign_id INTEGER,
             schedule_name TEXT,
             frequency TEXT,
-            send_times TEXT,
+            schedule_json TEXT,
             target_platforms TEXT,
             is_active INTEGER DEFAULT 1,
             next_send_telegram TEXT,

--- a/setup_advertising.py
+++ b/setup_advertising.py
@@ -24,7 +24,7 @@ SQL_TABLES = [
         campaign_id INTEGER,
         schedule_name TEXT,
         frequency TEXT,
-        send_times TEXT,
+        schedule_json TEXT,
         target_platforms TEXT,
         is_active INTEGER DEFAULT 1,
         next_send_telegram TEXT,

--- a/tests/test_advertising.py
+++ b/tests/test_advertising.py
@@ -1,6 +1,7 @@
 import sqlite3
 import sys
 import types
+import json
 
 sys.modules.setdefault(
     "telebot",
@@ -66,6 +67,19 @@ CREATE_TARGET_GROUPS_TABLE = """CREATE TABLE IF NOT EXISTS target_groups (
     notes TEXT
 )"""
 
+CREATE_SCHEDULES_TABLE = """CREATE TABLE IF NOT EXISTS campaign_schedules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER,
+    schedule_name TEXT,
+    frequency TEXT,
+    schedule_json TEXT,
+    target_platforms TEXT,
+    is_active INTEGER DEFAULT 1,
+    next_send_telegram TEXT,
+    created_date TEXT,
+    FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
+)"""
+
 
 def init_ads_db(path):
     conn = sqlite3.connect(path)
@@ -73,6 +87,7 @@ def init_ads_db(path):
     cur.execute(CREATE_CAMPAIGNS_TABLE)
     cur.execute(CREATE_SEND_LOGS_TABLE)
     cur.execute(CREATE_TARGET_GROUPS_TABLE)
+    cur.execute(CREATE_SCHEDULES_TABLE)
     conn.commit()
     conn.close()
 
@@ -138,4 +153,23 @@ def test_send_campaign_now(tmp_path, monkeypatch):
     assert len(rows) == 1
     assert sent == [("tg", "111", "Hi")]
     assert all(r[1] == "sent" for r in rows)
+
+
+def test_schedule_campaign_records_json(tmp_path):
+    db_path = tmp_path / "ads.db"
+    init_ads_db(db_path)
+    manager = AdvertisingManager(str(db_path))
+    camp_id = manager.create_campaign({"name": "Camp2", "message_text": "Hi", "created_by": 1})
+
+    ok, msg = manager.schedule_campaign(camp_id, ["lunes"], ["10:00", "15:00"])
+    assert ok
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT schedule_json FROM campaign_schedules WHERE campaign_id = ?", (camp_id,))
+    row = cur.fetchone()
+    conn.close()
+    assert row is not None
+    data = json.loads(row[0])
+    assert data == {"lunes": ["10:00", "15:00"]}
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,57 @@
+import sqlite3
+import json
+from advertising_system.scheduler import CampaignScheduler
+
+CREATE_CAMPAIGNS = """CREATE TABLE campaigns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    message_text TEXT,
+    media_file_id TEXT,
+    media_type TEXT,
+    button1_text TEXT,
+    button1_url TEXT,
+    button2_text TEXT,
+    button2_url TEXT,
+    status TEXT
+)"""
+
+CREATE_SCHEDULES = """CREATE TABLE campaign_schedules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    campaign_id INTEGER,
+    schedule_name TEXT,
+    frequency TEXT,
+    schedule_json TEXT,
+    target_platforms TEXT,
+    is_active INTEGER DEFAULT 1,
+    next_send_telegram TEXT,
+    created_date TEXT
+)"""
+
+
+def test_get_pending_sends_json(monkeypatch, tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(CREATE_CAMPAIGNS)
+    cur.execute(CREATE_SCHEDULES)
+    cur.execute(
+        "INSERT INTO campaigns (name, message_text, media_file_id, media_type, button1_text, button1_url, button2_text, button2_url, status)"
+        " VALUES ('c','m',NULL,NULL,NULL,NULL,NULL,NULL,'active')"
+    )
+    camp_id = cur.lastrowid
+    schedule = {"lunes": ["10:00"]}
+    cur.execute("INSERT INTO campaign_schedules (campaign_id, schedule_name, frequency, schedule_json, target_platforms, is_active, created_date) VALUES (?,?,?,?,?,1,'now')", (camp_id,'manual','weekly',json.dumps(schedule),'telegram'))
+    conn.commit()
+    conn.close()
+
+    import advertising_system.scheduler as mod
+    class DummyDatetime(mod.datetime):
+        @classmethod
+        def now(cls):
+            return cls(2023, 1, 2, 10, 0)  # Monday
+    monkeypatch.setattr(mod, 'datetime', DummyDatetime)
+
+    sch = CampaignScheduler(str(db_path))
+    rows = sch.get_pending_sends()
+    assert len(rows) == 1
+


### PR DESCRIPTION
## Summary
- add `schedule_json` column for campaign schedules
- parse new schedule format when checking for pending sends
- update `schedule_campaign` API and admin command
- test new schedule JSON handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9a8a6be08333a8c27fbf06496ddf