### PR TITLE
Handle missing manual upload file

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -664,6 +664,17 @@ def text_analytics(message_text, chat_id):
                 bd[str(chat_id)] = 11
 
         elif sost_num == 11:
+            try:
+                with open(f'data/Temp/{chat_id}upload_file.txt', encoding='utf-8'):
+                    pass
+            except FileNotFoundError:
+                bot.send_message(chat_id, '❌ La sesión anterior se perdió.')
+                with shelve.open(files.sost_bd) as bd:
+                    if str(chat_id) in bd:
+                        del bd[str(chat_id)]
+                in_adminka(chat_id, 'Volver al menú principal', None, None)
+                return
+
             manual_flag = '1' if message_text == 'Sí' else '0'
             with open('data/Temp/' + str(chat_id) + 'good_manual.txt', 'w', encoding='utf-8') as f:
                 f.write(manual_flag)


### PR DESCRIPTION
## Summary
- handle missing `upload_file.txt` when in admin state 11

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da88b82c08333ba600977e64ea751