### PR TITLE
Add category management for products

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Al crear una nueva posición se preguntará ahora **¿Entrega manual?**. Si resp
 *Sí*, el bot omitirá el formato del producto y utilizará el mensaje configurado
 anteriormente para avisar al comprador.
 
+Además, cada producto puede pertenecer a una **categoría**. Desde el panel principal está disponible el menú *🏷️ Categorías* para crear, eliminar o ver categorías. Al crear un producto se solicitará elegir una existente o registrar una nueva.
+
 ### Difusión
 
 La opción **📣 Difusión** permite enviar un anuncio de forma masiva. Tras

--- a/adminka.py
+++ b/adminka.py
@@ -80,6 +80,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
             user_markup.row('📢 Marketing')
+            user_markup.row('🏷️ Categorías')
             user_markup.row('💸 Descuentos')
             user_markup.row('⚙️ Otros')
             bot.send_message(chat_id, '¡Has ingresado al panel de administración del bot!\nPara salir, presiona /start', reply_markup=user_markup)
@@ -410,6 +411,39 @@ def in_adminka(chat_id, message_text, username, name_user):
             stats_text = f"""📢 **Sistema de Marketing**\n\n📊 **Estadísticas de hoy:**\n- Mensajes enviados: {today_stats['sent']}\n- Tasa de éxito: {today_stats['success_rate']}%\n- Grupos alcanzados: {today_stats['groups']}\n\nSelecciona una opción:"""
 
             bot.send_message(chat_id, stats_text, reply_markup=user_markup, parse_mode='Markdown')
+
+        elif '🏷️ Categorías' == message_text:
+            user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+            user_markup.row('Añadir categoría', 'Eliminar categoría')
+            user_markup.row('Ver categorías')
+            user_markup.row('Volver al menú principal')
+            bot.send_message(chat_id, 'Gestión de categorías', reply_markup=user_markup)
+
+        elif 'Añadir categoría' == message_text:
+            bot.send_message(chat_id, 'Ingrese el nombre de la nueva categoría:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 61
+
+        elif 'Eliminar categoría' == message_text:
+            cats = dop.list_categories()
+            if not cats:
+                bot.send_message(chat_id, 'No existen categorías para eliminar.')
+            else:
+                user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                for _cid, cname in cats:
+                    user_markup.row(cname)
+                user_markup.row('Volver al menú principal')
+                bot.send_message(chat_id, 'Seleccione la categoría a eliminar:', reply_markup=user_markup)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 60
+
+        elif 'Ver categorías' == message_text:
+            cats = dop.list_categories()
+            if not cats:
+                bot.send_message(chat_id, 'No hay categorías registradas.')
+            else:
+                text = '*Categorías:*\n' + '\n'.join(f'- {c[1]}' for c in cats)
+                bot.send_message(chat_id, text, parse_mode='Markdown')
 
         elif '🎯 Nueva campaña' == message_text:
             key = telebot.types.InlineKeyboardMarkup()
@@ -748,9 +782,30 @@ def text_analytics(message_text, chat_id):
             with open('data/Temp/' + str(chat_id) + 'good_duration.txt', 'w', encoding='utf-8') as f:
                 f.write(str(duration_val))
 
-            key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Añadir producto a la tienda', callback_data='Añadir producto a la tienda'))
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
+            cats = dop.list_categories()
+            user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+            for _cid, cname in cats:
+                user_markup.row(cname)
+            user_markup.row('Nueva categoría')
+            user_markup.row('Volver al menú principal')
+            bot.send_message(chat_id, 'Elija una categoría para el producto:', reply_markup=user_markup)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 62
+
+        elif sost_num == 62:
+            if message_text == 'Nueva categoría':
+                bot.send_message(chat_id, 'Ingrese el nombre de la nueva categoría:')
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 61
+                return
+
+            cat_id = dop.get_category_id(message_text)
+            if cat_id is None:
+                bot.send_message(chat_id, '❌ Categoría no válida. Intente de nuevo.')
+                return
+
+            with open('data/Temp/' + str(chat_id) + 'good_category.txt', 'w', encoding='utf-8') as f:
+                f.write(str(cat_id))
 
             try:
                 with open('data/Temp/' + str(chat_id) + 'good_name.txt', encoding='utf-8') as f:
@@ -766,19 +821,29 @@ def text_analytics(message_text, chat_id):
                     minimum = f.read()
                 with open('data/Temp/' + str(chat_id) + 'good_price.txt', encoding='utf-8') as f:
                     price = f.read()
+                with open('data/Temp/' + str(chat_id) + 'good_duration.txt', encoding='utf-8') as f:
+                    duration_val = int(f.read())
             except FileNotFoundError:
                 session_expired(chat_id)
                 return
+
             duration_display = ''
             if duration_val > 0:
                 duration_display = f'\n*Duración:* {duration_val} días'
 
+            cat_name = dop.get_category_name(cat_id)
+            cat_line = f'\n*Categoría:* {cat_name}' if cat_name else ''
+
             manual_text = 'Sí' if manual_flag == '1' else 'No'
             summary = (
                 f'*Resumen del producto:*\n\n*Nombre:* {name}\n*Descripción:* {description}'
-                f'\n*Formato:* {format_display}\n*Cantidad mínima:* {minimum}\n*Precio:* ${price} USD{duration_display}'
+                f'\n*Formato:* {format_display}\n*Cantidad mínima:* {minimum}\n*Precio:* ${price} USD{duration_display}{cat_line}'
                 f'\n*Entrega manual:* {manual_text}'
             )
+
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Añadir producto a la tienda', callback_data='Añadir producto a la tienda'))
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
 
             media_temp = 'data/Temp/' + str(chat_id) + 'new_media.txt'
             if os.path.exists(media_temp):
@@ -800,6 +865,40 @@ def text_analytics(message_text, chat_id):
                 bot.send_message(chat_id, summary, parse_mode='MarkDown', reply_markup=key)
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
+
+        elif sost_num == 61:
+            cat_id = dop.create_category(message_text.strip())
+            if not cat_id:
+                bot.send_message(chat_id, '❌ No se pudo crear la categoría (posiblemente ya existe).')
+                return
+
+            with open('data/Temp/' + str(chat_id) + 'good_category.txt', 'w', encoding='utf-8') as f:
+                f.write(str(cat_id))
+
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 62
+
+            cats = dop.list_categories()
+            user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+            for _cid, cname in cats:
+                user_markup.row(cname)
+            user_markup.row('Nueva categoría')
+            user_markup.row('Volver al menú principal')
+            bot.send_message(chat_id, 'Categoría creada. Seleccione la categoría para continuar:', reply_markup=user_markup)
+
+        elif sost_num == 60:
+            cat_id = dop.get_category_id(message_text)
+            if cat_id is None:
+                bot.send_message(chat_id, '❌ Categoría no encontrada.')
+            else:
+                con = db.get_db_connection()
+                cursor = con.cursor()
+                cursor.execute('DELETE FROM categories WHERE id = ?', (cat_id,))
+                con.commit()
+                bot.send_message(chat_id, 'Categoría eliminada.')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            in_adminka(chat_id, '🏷️ Categorías', None, None)
 
         elif sost_num == 6:
             con = db.get_db_connection()
@@ -1607,10 +1706,17 @@ def ad_inline(callback_data, chat_id, message_id):
 
         if manual_flag == '1':
             format_type = 'manual'
+        category_id = None
+        try:
+            with open('data/Temp/' + str(chat_id) + 'good_category.txt', encoding='utf-8') as f:
+                category_id = int(f.read())
+        except Exception:
+            pass
+
         cursor.execute(
             """
-            INSERT INTO goods (name, description, format, minimum, price, stored, additional_description, media_file_id, media_type, media_caption, duration_days, manual_delivery)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO goods (name, description, format, minimum, price, stored, additional_description, media_file_id, media_type, media_caption, duration_days, manual_delivery, category_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name,
@@ -1625,6 +1731,7 @@ def ad_inline(callback_data, chat_id, message_id):
                 media_caption,
                 duration_days,
                 int(manual_flag),
+                category_id,
             ),
         )
         con.commit()
@@ -1653,6 +1760,10 @@ def ad_inline(callback_data, chat_id, message_id):
 
         if os.path.exists(media_temp):
             os.remove(media_temp)
+        try:
+            os.remove('data/Temp/' + str(chat_id) + 'good_category.txt')
+        except Exception:
+            pass
         
         user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
         user_markup.row('Añadir nueva posición en el escaparate', 'Eliminar posición')

--- a/dop.py
+++ b/dop.py
@@ -20,6 +20,12 @@ def ensure_database_schema():
         columns = [c[1] for c in cursor.fetchall()]
         updated = False
 
+        # Asegurar tabla de categorías
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL)"
+        )
+        con.commit()
+
         if 'additional_description' not in columns:
             cursor.execute("ALTER TABLE goods ADD COLUMN additional_description TEXT DEFAULT ''")
             updated = True
@@ -37,6 +43,9 @@ def ensure_database_schema():
             updated = True
         if 'manual_delivery' not in columns:
             cursor.execute("ALTER TABLE goods ADD COLUMN manual_delivery INTEGER DEFAULT 0")
+            updated = True
+        if 'category_id' not in columns:
+            cursor.execute("ALTER TABLE goods ADD COLUMN category_id INTEGER")
             updated = True
 
         if updated:
@@ -210,6 +219,67 @@ def get_goods():
         return goods
     except:
         return []
+
+def list_categories():
+    """Devuelve lista de categorías (id, nombre)."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("SELECT id, name FROM categories ORDER BY name")
+        return cursor.fetchall()
+    except Exception as e:
+        print(f"Error listando categorías: {e}")
+        return []
+
+def create_category(name):
+    """Crear una categoría y devolver su ID."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("INSERT INTO categories (name) VALUES (?)", (name,))
+        con.commit()
+        return cursor.lastrowid
+    except sqlite3.IntegrityError:
+        cursor.execute("SELECT id FROM categories WHERE name = ?", (name,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        print(f"Error creando categoría: {e}")
+        return None
+
+def get_category_id(name):
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("SELECT id FROM categories WHERE name = ?", (name,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        print(f"Error obteniendo id de categoría: {e}")
+        return None
+
+def get_category_name(cat_id):
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("SELECT name FROM categories WHERE id = ?", (cat_id,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        print(f"Error obteniendo nombre de categoría: {e}")
+        return None
+
+def assign_product_category(product, category_id):
+    """Asigna una categoría a un producto."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("UPDATE goods SET category_id = ? WHERE name = ?", (category_id, product))
+        con.commit()
+        return True
+    except Exception as e:
+        print(f"Error asignando categoría: {e}")
+        return False
 
 def get_stored(name_good):
     try:
@@ -1029,14 +1099,19 @@ def get_product_full_info(good_name):
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
-        cursor.execute("""
-            SELECT name, description, additional_description, format, minimum, price, duration_days, manual_delivery
-            FROM goods WHERE name = ?
-        """, (good_name,))
+        cursor.execute(
+            """
+            SELECT g.name, g.description, g.additional_description, g.format, g.minimum, g.price,
+                   g.duration_days, g.manual_delivery, c.name
+            FROM goods g LEFT JOIN categories c ON g.category_id = c.id
+            WHERE g.name = ?
+        """,
+            (good_name,),
+        )
         result = cursor.fetchone()
 
         if result:
-            name, description, additional_desc, format, minimum, price, duration_days, manual = result
+            name, description, additional_desc, format, minimum, price, duration_days, manual, category = result
             return {
                 'name': name,
                 'description': description,
@@ -1045,7 +1120,8 @@ def get_product_full_info(good_name):
                 'minimum': minimum,
                 'price': price,
                 'duration_days': duration_days,
-                'manual_delivery': bool(manual)
+                'manual_delivery': bool(manual),
+                'category': category,
             }
         else:
             return None
@@ -1068,7 +1144,12 @@ def format_product_basic_info(good_name):
         info_text = f"""🛍️ **{product_info['name']}**
 
 📝 **Descripción:**
-{product_info['description']}
+{product_info['description']}"""
+
+        if product_info.get('category'):
+            info_text += f"\n🏷️ **Categoría:** {product_info['category']}"
+
+        info_text += f"""
 
 💰 **Precio:** ${product_info['price']} USD
 📦 **Cantidad mínima:** {product_info['minimum']}
@@ -1209,21 +1290,27 @@ def format_product_with_media(product_name):
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
-        cursor.execute("""
-            SELECT name, description, price, media_file_id, media_type, media_caption, duration_days, manual_delivery
-            FROM goods
-            WHERE name = ?
-        """, (product_name,))
+        cursor.execute(
+            """
+            SELECT g.name, g.description, g.price, g.media_file_id, g.media_type, g.media_caption,
+                   g.duration_days, g.manual_delivery, c.name
+            FROM goods g LEFT JOIN categories c ON g.category_id = c.id
+            WHERE g.name = ?
+        """,
+            (product_name,),
+        )
         result = cursor.fetchone()
         
         if not result:
             return None
             
-        name, description, price, file_id, media_type, caption, duration, manual = result
-        
+        name, description, price, file_id, media_type, caption, duration, manual, category = result
+
         info = f"🎯 **{name}**\n"
         info += f"💰 **Precio:** ${price} USD\n"
         info += f"📝 **Descripción:** {description}\n"
+        if category:
+            info += f"🏷️ **Categoría:** {category}\n"
         if duration not in (None, 0):
             info += f"⏳ **Duración:** {duration} días\n"
 

--- a/init_db.py
+++ b/init_db.py
@@ -23,6 +23,15 @@ def create_database():
     conn = sqlite3.connect('data/db/main_data.db')
     cursor = conn.cursor()
     
+    # Tabla de categorías
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS categories (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL
+        )
+    ''')
+    print("✓ Tabla 'categories' creada")
+
     # Crear tabla de productos
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS goods (
@@ -37,7 +46,9 @@ def create_database():
             media_type TEXT,
             media_caption TEXT,
             duration_days INTEGER DEFAULT NULL,
-            manual_delivery INTEGER DEFAULT 0
+            manual_delivery INTEGER DEFAULT 0,
+            category_id INTEGER,
+            FOREIGN KEY (category_id) REFERENCES categories(id)
         )
     ''')
     print("✓ Tabla 'goods' creada")

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,62 @@
+import importlib, sqlite3, sys, types
+from pathlib import Path
+import builtins
+
+
+def setup_dop(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+    sys.modules.setdefault(
+        "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+    )
+
+    telebot_stub = types.SimpleNamespace(
+        TeleBot=lambda *a, **k: types.SimpleNamespace(),
+        types=types.SimpleNamespace(InlineKeyboardMarkup=lambda *a, **k: None,
+                                    InlineKeyboardButton=lambda *a, **k: None),
+    )
+    sys.modules["telebot"] = telebot_stub
+    bot_stub = telebot_stub.TeleBot()
+    sys.modules["bot_instance"] = types.SimpleNamespace(bot=bot_stub)
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    import files
+    monkeypatch.setattr(files, "main_db", str(tmp_path / "main.db"))
+
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE goods (name TEXT PRIMARY KEY, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT)")
+    conn.commit()
+    conn.close()
+
+    sys.modules.pop("db", None)
+    sys.modules.pop("dop", None)
+    dop = importlib.import_module("dop")
+    return dop
+
+
+def test_category_creation_and_assignment(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='categories'")
+    assert cur.fetchone() is not None
+
+    cur.execute("PRAGMA table_info(goods)")
+    cols = [c[1] for c in cur.fetchall()]
+    assert "category_id" in cols
+
+    cat_id = dop.create_category("Test")
+    assert cat_id
+
+    cur.execute("INSERT INTO goods (name, description, format, minimum, price, stored, category_id) VALUES ('P', 'd', 'text', 1, 2, 'f', ?)", (cat_id,))
+    conn.commit()
+
+    cur.execute("SELECT category_id FROM goods WHERE name='P'")
+    assert cur.fetchone()[0] == cat_id
+    conn.close()


### PR DESCRIPTION
## Summary
- create categories table and link it to goods
- show categories in product info
- add category management menu
- handle category choice during product creation
- document categories in README
- test category support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db025d7448333a2ea230613641e53