### PR TITLE
Add purchase history option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ el bot.
 
 El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.
 
+Desde ese menú también podrás pulsar **"Mis compras"** para revisar un resumen de todos los productos que hayas adquirido.
+
 ## Panel de administración
 
 Al entrar verás botones para gestionar las distintas funciones del bot. Entre

--- a/dop.py
+++ b/dop.py
@@ -901,6 +901,31 @@ def search_user_purchases(search_term):
         return f"❌ Error buscando compras: {e}"
 
 
+def get_user_purchases(user_id):
+    con = db.get_db_connection()
+    cursor = con.cursor()
+    cursor.execute(
+        "SELECT name_good, amount, price FROM purchases "
+        "WHERE id = ? ORDER BY rowid DESC",
+        (user_id,)
+    )
+    rows = cursor.fetchall()
+    if not rows:
+        return "❌ No tienes compras registradas."
+    response = "📋 **Tus compras:**\n\n"
+    total = 0
+    for idx, (product, qty, price) in enumerate(rows, 1):
+        total += price
+        response += (
+            f"🛒 **Compra #{idx}**\n"
+            f"📦 {product} x{qty}\n"
+            f"💰 ${price} USD\n"
+            "━━━━━━━━━━━━━━━━━━━━\n"
+        )
+    response += f"\n💎 **Total gastado:** ${total} USD"
+    return response
+
+
 def get_discount_config():
     """Obtiene la configuración de descuentos"""
     try:

--- a/main.py
+++ b/main.py
@@ -56,6 +56,8 @@ def send_main_menu(chat_id, username, name):
     """Enviar el mensaje de inicio con el teclado principal"""
     key = telebot.types.InlineKeyboardMarkup()
     key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+    key.add(telebot.types.InlineKeyboardButton(
+        text='📜 Mis compras', callback_data='Ver mis compras'))
     if dop.check_message('start'):
         with shelve.open(files.bot_message_bd) as bd:
             start_message = bd['start']
@@ -113,7 +115,9 @@ def message_send(message):
             elif dop.check_message('start') is True:
                 key = telebot.types.InlineKeyboardMarkup()
                 key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
-                with shelve.open(files.bot_message_bd) as bd: 
+                key.add(telebot.types.InlineKeyboardButton(
+                    text='📜 Mis compras', callback_data='Ver mis compras'))
+                with shelve.open(files.bot_message_bd) as bd:
                     start_message = bd['start']
                 start_message = start_message.replace('username', message.chat.username)
                 start_message = start_message.replace('name', message.from_user.first_name)
@@ -345,14 +349,26 @@ def inline(callback):
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=False, text='ℹ️ Información adicional mostrada')
 
 
+        elif callback.data == 'Ver mis compras':
+            history = dop.get_user_purchases(callback.message.chat.id)
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(
+                text='🏠 Inicio', callback_data='Volver al inicio'))
+            bot.answer_callback_query(callback.id)
+            dop.safe_edit_message(bot, callback.message,
+                                  history, reply_markup=key, parse_mode='Markdown')
+
+
         elif callback.data == 'Volver al inicio':
             if callback.message.chat.username:
-                if dop.get_sost(callback.message.chat.id) is True: 
-                    with shelve.open(files.sost_bd) as bd: 
+                if dop.get_sost(callback.message.chat.id) is True:
+                    with shelve.open(files.sost_bd) as bd:
                         if str(callback.message.chat.id) in bd:
                             del bd[str(callback.message.chat.id)]
                 key = telebot.types.InlineKeyboardMarkup()
                 key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+                key.add(telebot.types.InlineKeyboardButton(
+                    text='📜 Mis compras', callback_data='Ver mis compras'))
                 if dop.check_message('start'):
                     with shelve.open(files.bot_message_bd) as bd:
                         start_message = bd['start']


### PR DESCRIPTION
## Summary
- let users see their purchases with `get_user_purchases`
- show "Mis compras" button in main menus
- handle `Ver mis compras` callback in the bot
- document how to see purchase history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686db4d3874c83338204f8abcc8bb69f