### PR TITLE
Add shop_id tracking for advertising campaigns

### DIFF
--- a/advertising_system/admin_integration.py
+++ b/advertising_system/admin_integration.py
@@ -23,6 +23,8 @@ def create_campaign_from_admin(data):
     """Crear una campaña mostrando un mensaje apto para la interfaz admin."""
 
     try:
+        data = dict(data)
+        data.setdefault('shop_id', _manager.shop_id)
         campaign_id = _manager.create_campaign(data)
         return True, f"Campaña creada con ID {campaign_id}"
     except Exception as exc:

--- a/advertising_system/campaign_database.py
+++ b/advertising_system/campaign_database.py
@@ -26,7 +26,8 @@ class CampaignDB:
                 data.get('media_type'), data.get('media_caption'),
                 data.get('button1_text'), data.get('button1_url'),
                 data.get('button2_text'), data.get('button2_url'),
-                datetime.now().isoformat(), data.get('created_by'), self.shop_id
+                datetime.now().isoformat(), data.get('created_by'),
+                data.get('shop_id', self.shop_id)
             )
         )
         campaign_id = cursor.lastrowid

--- a/dop.py
+++ b/dop.py
@@ -68,6 +68,15 @@ def ensure_database_schema():
             cursor.execute("ALTER TABLE goods ADD COLUMN shop_id INTEGER DEFAULT 1")
             updated = True
 
+        cursor.execute("PRAGMA table_info(campaigns)")
+        camp_cols = [c[1] for c in cursor.fetchall()]
+        if 'shop_id' not in camp_cols:
+            try:
+                cursor.execute("ALTER TABLE campaigns ADD COLUMN shop_id INTEGER DEFAULT 1")
+                updated = True
+            except sqlite3.OperationalError:
+                pass
+
         if updated:
             con.commit()
         con.commit()

--- a/setup_advertising.py
+++ b/setup_advertising.py
@@ -16,6 +16,7 @@ SQL_TABLES = [
         status TEXT DEFAULT 'active',
         created_date TEXT,
         created_by INTEGER,
+        shop_id INTEGER DEFAULT 1,
         daily_limit INTEGER DEFAULT 3,
         priority INTEGER DEFAULT 1
     )""",
@@ -29,6 +30,7 @@ SQL_TABLES = [
         is_active INTEGER DEFAULT 1,
         next_send_telegram TEXT,
         created_date TEXT,
+        shop_id INTEGER DEFAULT 1,
         FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
     )""",
     """CREATE TABLE IF NOT EXISTS target_groups (
@@ -41,14 +43,16 @@ SQL_TABLES = [
         last_sent TEXT,
         success_rate REAL DEFAULT 1.0,
         added_date TEXT,
-        notes TEXT
+        notes TEXT,
+        shop_id INTEGER DEFAULT 1
     )""",
     """CREATE TABLE IF NOT EXISTS platform_config (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         platform TEXT UNIQUE,
         config_data TEXT,
         is_active INTEGER DEFAULT 1,
-        last_updated TEXT
+        last_updated TEXT,
+        shop_id INTEGER DEFAULT 1
     )""",
     """CREATE TABLE IF NOT EXISTS send_logs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -59,6 +63,7 @@ SQL_TABLES = [
         sent_date TEXT,
         response_time REAL,
         error_message TEXT,
+        shop_id INTEGER DEFAULT 1,
         FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
     )""",
     """CREATE TABLE IF NOT EXISTS daily_stats (
@@ -68,13 +73,15 @@ SQL_TABLES = [
         telegram_sent INTEGER DEFAULT 0,
         success_rate REAL DEFAULT 0,
         failed_count INTEGER DEFAULT 0,
-        avg_response_time REAL DEFAULT 0
+        avg_response_time REAL DEFAULT 0,
+        shop_id INTEGER DEFAULT 1
     )""",
     """CREATE TABLE IF NOT EXISTS rate_limit_logs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         platform TEXT,
         success INTEGER,
-        timestamp TEXT
+        timestamp TEXT,
+        shop_id INTEGER DEFAULT 1
     )"""
 ]
 


### PR DESCRIPTION
## Summary
- store shop_id when creating campaigns from the admin panel
- respect provided shop_id when inserting campaigns
- ensure existing databases include campaigns.shop_id
- include shop_id column in setup_advertising.py schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686de0fc50b8833389499f130214287f