### PR TITLE
Add per-shop payment credentials

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1199,17 +1199,15 @@ def text_analytics(message_text, chat_id):
             try:
                 with open('data/Temp/' + str(chat_id) + 'paypal_client.txt', encoding='utf-8') as f:
                     client_id = f.read()
-            
-                con = db.get_db_connection()
-                cursor = con.cursor()
-                cursor.execute("INSERT OR REPLACE INTO paypal_data VALUES(?, ?, ?)", (client_id, message_text, 1))
-                con.commit()
-                
+
+                shop_id = dop.get_shop_id(chat_id)
+                dop.save_paypaldata(client_id, message_text, 1, shop_id)
+
                 with shelve.open(files.payments_bd) as bd:
                     bd['paypal'] = '✅'
-                
+
                 bot.send_message(chat_id, '¡Credenciales PayPal guardadas exitosamente!')
-                with shelve.open(files.sost_bd) as bd: 
+                with shelve.open(files.sost_bd) as bd:
                     del bd[str(chat_id)]
             except FileNotFoundError:
                 session_expired(chat_id)
@@ -1252,16 +1250,14 @@ def text_analytics(message_text, chat_id):
                 with open('data/Temp/' + str(chat_id) + 'binance_secret.txt', encoding='utf-8') as f:
                     api_secret = f.read()
             
-                con = db.get_db_connection()
-                cursor = con.cursor()
-                cursor.execute("INSERT OR REPLACE INTO binance_data VALUES(?, ?, ?)", (api_key, api_secret, message_text))
-                con.commit()
-                
+                shop_id = dop.get_shop_id(chat_id)
+                dop.save_binancedata(api_key, api_secret, message_text, shop_id)
+
                 with shelve.open(files.payments_bd) as bd:
                     bd['binance'] = '✅'
-                
+
                 bot.send_message(chat_id, '¡Credenciales Binance guardadas exitosamente!')
-                with shelve.open(files.sost_bd) as bd: 
+                with shelve.open(files.sost_bd) as bd:
                     del bd[str(chat_id)]
             except FileNotFoundError:
                 session_expired(chat_id)

--- a/dop.py
+++ b/dop.py
@@ -781,29 +781,69 @@ def get_description(name_good):
         print(f"Error obteniendo descripción: {e}")
         return "Error obteniendo información del producto"
 
-def get_paypaldata():
+def get_paypaldata(shop_id=1):
+    """Obtener credenciales PayPal asociadas a una tienda."""
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
-        cursor.execute("SELECT client_id, client_secret, sandbox FROM paypal_data;")
+        cursor.execute(
+            "SELECT client_id, client_secret, sandbox FROM paypal_data WHERE shop_id = ? ORDER BY rowid DESC LIMIT 1;",
+            (shop_id,),
+        )
         result = cursor.fetchone()
         if result:
             return result[0], result[1], bool(result[2])
         return None
-    except:
+    except Exception:
         return None
 
-def get_binancedata():
+def get_binancedata(shop_id=1):
+    """Obtener credenciales Binance asociadas a una tienda."""
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
-        cursor.execute("SELECT api_key, api_secret, merchant_id FROM binance_data;")
+        cursor.execute(
+            "SELECT api_key, api_secret, merchant_id FROM binance_data WHERE shop_id = ? ORDER BY rowid DESC LIMIT 1;",
+            (shop_id,),
+        )
         result = cursor.fetchone()
         if result:
             return result[0], result[1], result[2]
         return None
-    except:
+    except Exception:
         return None
+
+def save_paypaldata(client_id, client_secret, sandbox=1, shop_id=1):
+    """Guardar o actualizar credenciales PayPal para una tienda."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("DELETE FROM paypal_data WHERE shop_id = ?", (shop_id,))
+        cursor.execute(
+            "INSERT INTO paypal_data (client_id, client_secret, sandbox, shop_id) VALUES (?, ?, ?, ?)",
+            (client_id, client_secret, int(bool(sandbox)), shop_id),
+        )
+        con.commit()
+        return True
+    except Exception as e:
+        print(f"Error guardando PayPal data: {e}")
+        return False
+
+def save_binancedata(api_key, api_secret, merchant_id, shop_id=1):
+    """Guardar o actualizar credenciales Binance para una tienda."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute("DELETE FROM binance_data WHERE shop_id = ?", (shop_id,))
+        cursor.execute(
+            "INSERT INTO binance_data (api_key, api_secret, merchant_id, shop_id) VALUES (?, ?, ?, ?)",
+            (api_key, api_secret, merchant_id, shop_id),
+        )
+        con.commit()
+        return True
+    except Exception as e:
+        print(f"Error guardando Binance data: {e}")
+        return False
 
 def check_paypal_valid(client_id, client_secret, sandbox=True):
     try:
@@ -843,13 +883,14 @@ def check_binance_valid(api_key, api_secret):
     except:
         return False
 
-def payments_checkvkl():
+def payments_checkvkl(shop_id=1):
+    """Verificar métodos de pago activos para una tienda."""
     active_payment = []
     
     # Verificar PayPal
-    if check_vklpayments('paypal') == '✅' and get_paypaldata() != None: 
+    if check_vklpayments('paypal') == '✅' and get_paypaldata(shop_id) != None:
         active_payment.append('paypal')
-    elif check_vklpayments('paypal') == '✅' and get_paypaldata() == None:
+    elif check_vklpayments('paypal') == '✅' and get_paypaldata(shop_id) == None:
         for admin_id in get_adminlist(): 
             try:
                 bot.send_message(admin_id, '¡Faltan datos de PayPal en la base de datos! Se desactivó automáticamente para recibir pagos.')
@@ -862,9 +903,9 @@ def payments_checkvkl():
             pass
 
     # Verificar Binance
-    if check_vklpayments('binance') == '✅' and get_binancedata() != None: 
+    if check_vklpayments('binance') == '✅' and get_binancedata(shop_id) != None:
         active_payment.append('binance')
-    elif check_vklpayments('binance') == '✅' and get_binancedata() == None:
+    elif check_vklpayments('binance') == '✅' and get_binancedata(shop_id) == None:
         for admin_id in get_adminlist(): 
             try:
                 bot.send_message(admin_id, '¡Faltan datos de Binance en la base de datos! Se desactivó automáticamente para recibir pagos.')

--- a/main.py
+++ b/main.py
@@ -412,7 +412,7 @@ def inline(callback):
                 return
             if dop.amount_of_goods(name_good, shop_id_cb) == 0:
                 bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='❌ Producto agotado - No disponible para compra')
-            elif dop.payments_checkvkl() == None:
+            elif dop.payments_checkvkl(shop_id_cb) == None:
                 bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='💳 Los pagos están temporalmente desactivados')
             else:
                 key = telebot.types.InlineKeyboardMarkup()

--- a/payments.py
+++ b/payments.py
@@ -26,11 +26,12 @@ def creat_bill_paypal(chat_id, callback_id, message_id, sum_amount, name_good, a
         bot.answer_callback_query(callback_query_id=callback_id, show_alert=True, text='PayPal no está disponible!')
         return
         
-    if dop.get_paypaldata() == None: 
+    shop_id = dop.get_user_shop(chat_id)
+    if dop.get_paypaldata(shop_id) == None:
         bot.answer_callback_query(callback_query_id=callback_id, show_alert=True, text='PayPal no está configurado en este momento!')
         return
-        
-    client_id, client_secret, sandbox = dop.get_paypaldata()
+
+    client_id, client_secret, sandbox = dop.get_paypaldata(shop_id)
     
     # Configurar PayPal
     if sandbox:
@@ -158,13 +159,14 @@ def check_oplata_paypal(chat_id, username, callback_id, first_name, message_id):
 
 def creat_bill_binance(chat_id, callback_id, message_id, sum_amount, name_good, amount):
     """Crear solicitud de pago Binance CORREGIDA - Con ID en instrucciones"""
-    if dop.get_binancedata() == None: 
+    shop_id = dop.get_user_shop(chat_id)
+    if dop.get_binancedata(shop_id) == None:
         bot.answer_callback_query(callback_query_id=callback_id, show_alert=True, text='Binance Pay no está configurado en este momento!')
         return
     
     # Obtener tu Binance Pay ID
     try:
-        api_key, api_secret, binance_pay_id = dop.get_binancedata()
+        api_key, api_secret, binance_pay_id = dop.get_binancedata(shop_id)
         # binance_pay_id es tu 294603789
     except:
         binance_pay_id = "294603789"  # fallback
@@ -254,7 +256,8 @@ def check_oplata_binance(chat_id, username, callback_id, first_name, message_id)
     
     # Obtener tu Binance Pay ID
     try:
-        api_key, api_secret, binance_pay_id = dop.get_binancedata()
+        shop_id = dop.get_user_shop(chat_id)
+        api_key, api_secret, binance_pay_id = dop.get_binancedata(shop_id)
     except:
         binance_pay_id = "294603789"  # fallback
     

--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -62,7 +62,7 @@ def setup_payments(monkeypatch, tmp_path):
 
 def test_creat_bill_binance_records_payment(tmp_path, monkeypatch):
     payments, _ = setup_payments(monkeypatch, tmp_path)
-    monkeypatch.setattr(payments.dop, "get_binancedata", lambda: ("a", "b", "ID"))
+    monkeypatch.setattr(payments.dop, "get_binancedata", lambda shop_id=1: ("a", "b", "ID"))
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- support retrieving PayPal/Binance credentials by `shop_id`
- let admins save credentials for their own shop
- pass the current shop when creating payment bills
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686deb26030c8333b1aa22fcda32d633