### PR TITLE
Add shop rename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ El bot admite gestionar varias tiendas. El usuario cuyo ID figura en `TELEGRAM_A
 
 Desde allí puede crear nuevas tiendas y asignar el ID de Telegram de su administrador. Cada cliente, al enviar `/start`, verá la lista de tiendas disponibles y deberá elegir una para acceder al catálogo. Su elección se guarda para futuras visitas.
 
+Cada administrador puede renombrar su tienda desde **⚙️ Otros** usando la opción *Cambiar nombre de tienda*.
+
 Si vienes de una instalación antigua de una sola tienda, ejecuta `python migrate_add_shop_id.py` (o `init_db.py` si prefieres crear la base desde cero) para añadir la columna `shop_id` requerida.
 
 ## Panel de administración

--- a/adminka.py
+++ b/adminka.py
@@ -617,6 +617,7 @@ def in_adminka(chat_id, message_text, username, name_user):
         elif '⚙️ Otros' == message_text:
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
             user_markup.row('Añadir nuevo admin', 'Eliminar admin')
+            user_markup.row('Cambiar nombre de tienda')
             if chat_id == config.admin_id:
                 user_markup.row('🛍️ Gestionar tiendas')
             user_markup.row('Volver al menú principal')
@@ -643,6 +644,11 @@ def in_adminka(chat_id, message_text, username, name_user):
                 bot.send_message(chat_id, 'Seleccione qué admin desea eliminar', reply_markup=user_markup)
                 with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 22
+
+        elif message_text == 'Cambiar nombre de tienda':
+            bot.send_message(chat_id, 'Ingrese el nuevo nombre de la tienda:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 303
 
         elif message_text == '🛍️ Gestionar tiendas' and chat_id == config.admin_id:
             shops = dop.list_shops()
@@ -1300,6 +1306,16 @@ def text_analytics(message_text, chat_id):
             else:
                 bot.send_message(chat_id, '❌ Error asignando admin')
             in_adminka(chat_id, '🛍️ Gestionar tiendas', None, None)
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+
+        elif sost_num == 303:
+            shop_id = dop.get_shop_id(chat_id)
+            if dop.update_shop_name(shop_id, message_text.strip()):
+                bot.send_message(chat_id, 'Nombre de tienda actualizado.')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando nombre de tienda')
+            in_adminka(chat_id, '⚙️ Otros', None, None)
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
 

--- a/dop.py
+++ b/dop.py
@@ -711,6 +711,21 @@ def assign_admin_to_shop(shop_id, admin_id):
         print(f"Error asignando admin a tienda: {e}")
         return False
 
+def update_shop_name(shop_id, new_name):
+    """Cambiar el nombre de una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "UPDATE shops SET name = ? WHERE id = ?",
+            (new_name, shop_id),
+        )
+        con.commit()
+        return cur.rowcount > 0
+    except Exception as e:
+        print(f"Error actualizando nombre de tienda: {e}")
+        return False
+
 # ------------------------------------------------------------------
 # Funciones para la tienda seleccionada por cada usuario
 # ------------------------------------------------------------------

--- a/tests/test_shops.py
+++ b/tests/test_shops.py
@@ -19,3 +19,9 @@ def test_shop_functions(monkeypatch, tmp_path):
     ok = dop.assign_admin_to_shop(sid2, 5)
     assert ok
     assert dop.get_shop_id(5) == sid2
+
+    # Cambiar nombre de la tienda
+    renamed = dop.update_shop_name(sid2, "NuevaShop")
+    assert renamed
+    shops = dop.list_shops()
+    assert any(s[0] == sid2 and s[2] == "NuevaShop" for s in shops)


### PR DESCRIPTION
## Summary
- implement `update_shop_name` in `dop.py`
- allow admins to rename current shop from `⚙️ Otros`
- add rename state and menu entry in admin panel
- update tests for shop renaming
- document the new option in the multi-shop section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df2bc5f548333ae9c0e0497da2abd