### PR TITLE
Add rename category admin feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Al crear una nueva posición se preguntará ahora **¿Entrega manual?**. Si resp
 *Sí*, el bot omitirá el formato del producto y utilizará el mensaje configurado
 anteriormente para avisar al comprador.
 
-Además, cada producto puede pertenecer a una **categoría**. Desde el panel principal está disponible el menú *🏷️ Categorías* para crear, eliminar o ver categorías. Al crear un producto se solicitará elegir una existente o registrar una nueva.
+Además, cada producto puede pertenecer a una **categoría**. Desde el panel principal está disponible el menú *🏷️ Categorías* para crear, eliminar, renombrar o ver categorías. Al crear un producto se solicitará elegir una existente o registrar una nueva.
 
 ### Difusión
 

--- a/adminka.py
+++ b/adminka.py
@@ -422,6 +422,7 @@ def in_adminka(chat_id, message_text, username, name_user):
         elif '🏷️ Categorías' == message_text:
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
             user_markup.row('Añadir categoría', 'Eliminar categoría')
+            user_markup.row('Renombrar categoría')
             user_markup.row('Ver categorías')
             user_markup.row('Volver al menú principal')
             bot.send_message(chat_id, 'Gestión de categorías', reply_markup=user_markup)
@@ -443,6 +444,19 @@ def in_adminka(chat_id, message_text, username, name_user):
                 bot.send_message(chat_id, 'Seleccione la categoría a eliminar:', reply_markup=user_markup)
                 with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 60
+
+        elif 'Renombrar categoría' == message_text:
+            cats = dop.list_categories(shop_id)
+            if not cats:
+                bot.send_message(chat_id, 'No hay categorías para renombrar.')
+            else:
+                user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                for _cid, cname in cats:
+                    user_markup.row(cname)
+                user_markup.row('Volver al menú principal')
+                bot.send_message(chat_id, 'Seleccione la categoría a renombrar:', reply_markup=user_markup)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 63
 
         elif 'Ver categorías' == message_text:
             cats = dop.list_categories(shop_id)
@@ -928,6 +942,33 @@ def text_analytics(message_text, chat_id):
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
             in_adminka(chat_id, '🏷️ Categorías', None, None)
+
+        elif sost_num == 63:
+            temp_path = 'data/Temp/' + str(chat_id) + 'rename_cat.txt'
+            if not os.path.exists(temp_path):
+                cat_id = dop.get_category_id(message_text, shop_id)
+                if cat_id is None:
+                    bot.send_message(chat_id, '❌ Categoría no válida. Intente de nuevo.')
+                    return
+                with open(temp_path, 'w', encoding='utf-8') as f:
+                    f.write(str(cat_id))
+                bot.send_message(chat_id, 'Ingrese el nuevo nombre para la categoría:')
+            else:
+                try:
+                    with open(temp_path, encoding='utf-8') as f:
+                        cat_id = int(f.read())
+                except (FileNotFoundError, ValueError):
+                    session_expired(chat_id)
+                    return
+                success = dop.update_category_name(cat_id, message_text.strip(), shop_id)
+                if success:
+                    bot.send_message(chat_id, 'Categoría actualizada.')
+                else:
+                    bot.send_message(chat_id, '❌ Error al actualizar la categoría.')
+                os.remove(temp_path)
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                in_adminka(chat_id, '🏷️ Categorías', None, None)
 
         elif sost_num == 6:
             con = db.get_db_connection()

--- a/dop.py
+++ b/dop.py
@@ -332,6 +332,21 @@ def get_category_name(cat_id, shop_id=1):
         print(f"Error obteniendo nombre de categoría: {e}")
         return None
 
+def update_category_name(cat_id, new_name, shop_id=1):
+    """Cambiar el nombre de una categoría."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "UPDATE categories SET name = ? WHERE id = ? AND shop_id = ?",
+            (new_name, cat_id, shop_id),
+        )
+        con.commit()
+        return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error actualizando nombre de categoría: {e}")
+        return False
+
 def assign_product_category(product, category_id, shop_id=1):
     """Asigna una categoría a un producto."""
     try:

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -68,3 +68,16 @@ def test_category_creation_and_assignment(monkeypatch, tmp_path):
     assert row[0] == cat_id
     assert row[1] == 1
     conn.close()
+
+
+def test_update_category_name(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    cat_id = dop.create_category("Old")
+    assert cat_id
+
+    ok = dop.update_category_name(cat_id, "New", 1)
+    assert ok
+    assert dop.get_category_name(cat_id, 1) == "New"
+


### PR DESCRIPTION
## Summary
- allow renaming categories in dop utility module
- provide new admin menu option under "🏷️ Categorías" for renaming
- handle rename flow via new conversation state in admin bot
- document the new option in README
- test `update_category_name`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df85bc22083339d565b336be31953