### PR TITLE
Add .env.example and ignore real env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+TELEGRAM_BOT_TOKEN=YOUR_BOT_TOKEN
+TELEGRAM_ADMIN_ID=YOUR_ADMIN_ID
+# Token utilizado por advertising_cron.py (obligatorio)
+# Puedes definir múltiples tokens separados por comas
+TELEGRAM_TOKEN=YOUR_ADVERTISING_TOKEN

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ pip install -r requirements.txt
 ```
 
 4. Copia el archivo `.env.example` a `.env` (o crea uno nuevo).  El
-   archivo de ejemplo incluye los campos `TELEGRAM_BOT_TOKEN` y
-   `TELEGRAM_ADMIN_ID` como referencia, así que sólo debes reemplazar sus
-   valores con tus credenciales.  Si utilizarás el sistema de publicidad,
-   **debes** definir `TELEGRAM_TOKEN` con el token (o los tokens separados
-   por comas) que empleará `advertising_cron.py`; el script fallará si no
-   se configura esta variable.
+   archivo de ejemplo incluye los campos `TELEGRAM_BOT_TOKEN`,
+   `TELEGRAM_ADMIN_ID` y `TELEGRAM_TOKEN` como referencia, así que sólo
+   debes reemplazar sus valores con tus credenciales.  Si utilizarás el
+   sistema de publicidad, **debes** definir `TELEGRAM_TOKEN` con el token
+   (o los tokens separados por comas) que empleará `advertising_cron.py`;
+   el script fallará si no se configura esta variable.
 
    Puedes modificar la frecuencia de consulta al servidor de Telegram
    estableciendo las variables opcionales `POLL_INTERVAL`, `POLL_TIMEOUT`

--- a/env
+++ b/env
@@ -1,5 +1,0 @@
-TELEGRAM_BOT_TOKEN=7275890221:AAHjeLMyikGG_pnjA1SXtn1bC1UJ-G3UXDg
-TELEGRAM_ADMIN_ID=723745098
-# Token utilizado por advertising_cron.py (obligatorio)
-# Puedes definir múltiples tokens separados por comas
-TELEGRAM_TOKEN=7275890221:AAHjeLMyikGG_pnjA1SXtn1bC1UJ-G3UXDg


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for environment variables
- remove tracked `env` file and rely on `.env` for local settings
- mention `TELEGRAM_TOKEN` in README setup steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df9594cd4833384849a531208b82b