### PR TITLE
Add shop_id migration for advertising tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ python migrate_drop_subscriptions.py
 
 antes de iniciar la nueva versión del bot para eliminarlas de forma segura.
 
+Si ya habías usado el sistema de publicidad antes de soportar múltiples
+tiendas, ejecuta también:
+
+```bash
+python migrate_add_shop_id_ads.py
+```
+para añadir la columna `shop_id` en sus tablas.
+
 ## Uso
 
 Antes de iniciar el bot por primera vez se debe crear la estructura de la base de datos. Ejecuta:

--- a/migrate_add_shop_id_ads.py
+++ b/migrate_add_shop_id_ads.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Add shop_id column to advertising tables if missing."""
+import sqlite3
+
+
+def main():
+    conn = sqlite3.connect('data/db/main_data.db')
+    cur = conn.cursor()
+
+    tables = [
+        'send_logs',
+        'target_groups',
+        'campaign_schedules',
+        'platform_config',
+        'daily_stats',
+        'rate_limit_logs',
+    ]
+
+    for table in tables:
+        cur.execute(f"PRAGMA table_info({table})")
+        cols = [c[1] for c in cur.fetchall()]
+        if 'shop_id' not in cols:
+            cur.execute(f"ALTER TABLE {table} ADD COLUMN shop_id INTEGER DEFAULT 1")
+            print(f"✓ Columna 'shop_id' agregada a '{table}'")
+        else:
+            print(f"ℹ️ La tabla '{table}' ya tiene 'shop_id'")
+
+    conn.commit()
+    print("✓ Migración completada")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `migrate_add_shop_id_ads.py` script to update advertising tables
- document migration in the update section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dfbcb2b588333ab087a6aab686f4e