### PR TITLE
Add shop-users table and shop-specific broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Cada administrador puede renombrar su tienda desde **⚙️ Otros** usando la op
 
 Si vienes de una instalación antigua de una sola tienda, ejecuta `python migrate_add_shop_id.py` (o `init_db.py` si prefieres crear la base desde cero) para añadir la columna `shop_id` requerida.
 
+Para registrar la relación entre usuarios y tiendas existentes, ejecuta:
+
+```bash
+python migrate_create_shop_users.py
+```
+
+Esto creará la tabla `shop_users` necesaria para las difusiones por tienda.
+
 ### Nombre de la tienda
 
 Al crear una tienda se solicitará un nombre, el cual verán los clientes al elegir tienda después de enviar `/start`. Los administradores pueden cambiar este nombre más adelante desde **⚙️ Otros** → **✏️ Renombrar tienda**.

--- a/dop.py
+++ b/dop.py
@@ -95,6 +95,11 @@ def ensure_database_schema():
             except sqlite3.OperationalError:
                 pass
 
+        # Tabla que relaciona usuarios con tiendas
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS shop_users (user_id INTEGER PRIMARY KEY, shop_id INTEGER DEFAULT 1)"
+        )
+
         if updated:
             con.commit()
         con.commit()
@@ -215,14 +220,20 @@ def user_loger(chat_id=0):
         try:
             with open(files.users_list, encoding='utf-8') as f:
                 if not str(chat_id) in f.read():
-                    with open(files.users_list, 'a', encoding='utf-8') as f: 
+                    with open(files.users_list, 'a', encoding='utf-8') as f:
                         f.write(str(chat_id) + '\n')
         except:
-            with open(files.users_list, 'w', encoding='utf-8') as f: 
+            with open(files.users_list, 'w', encoding='utf-8') as f:
                 f.write(str(chat_id) + '\n')
-    
+        try:
+            # Registrar o actualizar la tienda del usuario
+            current = get_user_shop(chat_id)
+            set_user_shop(chat_id, current)
+        except Exception:
+            pass
+
     try:
-        with open(files.users_list, encoding='utf-8') as f: 
+        with open(files.users_list, encoding='utf-8') as f:
             return len(f.readlines())
     except:
         return 0
@@ -591,11 +602,16 @@ def broadcast_message(group, amount, text, media=None, shop_id=1):
 
     if group == 'all':
         try:
-            with open(files.users_list, encoding='utf-8') as f:
-                users = f.readlines()
+            con = db.get_db_connection()
+            cursor = con.cursor()
+            cursor.execute(
+                "SELECT user_id FROM shop_users WHERE shop_id = ? LIMIT ?;",
+                (shop_id, int(amount)),
+            )
+            users = cursor.fetchall()
 
-            while i < int(amount) and i < len(users):
-                chat_id = int(users[i].strip())
+            while i < len(users) and i < int(amount):
+                chat_id = int(users[i][0])
                 try:
                     if media:
                         _send_media_message(chat_id, text, media)
@@ -746,10 +762,15 @@ def update_shop_name(shop_id, new_name):
 # ------------------------------------------------------------------
 
 def set_user_shop(user_id, shop_id):
-    """Guardar la tienda elegida por un usuario."""
+    """Guardar la tienda elegida por un usuario en la base de datos."""
     try:
-        with shelve.open(files.user_shops_bd) as bd:
-            bd[str(user_id)] = int(shop_id)
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "INSERT OR REPLACE INTO shop_users (user_id, shop_id) VALUES (?, ?)",
+            (int(user_id), int(shop_id)),
+        )
+        con.commit()
     except Exception:
         pass
 
@@ -757,8 +778,14 @@ def set_user_shop(user_id, shop_id):
 def get_user_shop(user_id):
     """Obtener la tienda seleccionada por un usuario (por defecto 1)."""
     try:
-        with shelve.open(files.user_shops_bd) as bd:
-            return bd.get(str(user_id), 1)
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "SELECT shop_id FROM shop_users WHERE user_id = ?",
+            (int(user_id),),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 1
     except Exception:
         return 1
 

--- a/init_db.py
+++ b/init_db.py
@@ -88,6 +88,15 @@ def create_database():
         )
     ''')
     print("✓ Tabla 'buyers' creada")
+
+    # Tabla que relaciona usuarios con su tienda seleccionada
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS shop_users (
+            user_id INTEGER PRIMARY KEY,
+            shop_id INTEGER DEFAULT 1
+        )
+    ''')
+    print("✓ Tabla 'shop_users' creada")
     
 
 

--- a/migrate_create_shop_users.py
+++ b/migrate_create_shop_users.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Create shop_users table if it doesn't exist."""
+import db
+
+
+def main():
+    conn = db.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='shop_users'")
+    if cur.fetchone() is None:
+        cur.execute(
+            "CREATE TABLE shop_users (user_id INTEGER PRIMARY KEY, shop_id INTEGER DEFAULT 1)"
+        )
+        print("✓ Tabla 'shop_users' creada")
+    else:
+        print("ℹ️ La tabla 'shop_users' ya existe")
+    conn.commit()
+    print("✓ Migración completada")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_shop_users.py
+++ b/tests/test_shop_users.py
@@ -1,0 +1,37 @@
+import sqlite3
+from tests.test_categories import setup_dop
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    def send_message(self, cid, text):
+        self.sent.append((cid, text))
+
+
+def test_shop_user_registration_and_broadcast(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    # Reemplazar bot por stub
+    bot = DummyBot()
+    monkeypatch.setattr(dop, "bot", bot)
+
+    dop.set_user_shop(1, 1)
+    dop.set_user_shop(2, 2)
+
+    res = dop.broadcast_message("all", 10, "hi", shop_id=1)
+    assert "usuarios" in res
+    assert bot.sent == [(1, "hi")]
+    bot.sent.clear()
+
+    res = dop.broadcast_message("all", 10, "hello", shop_id=2)
+    assert bot.sent == [(2, "hello")]
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute("SELECT shop_id FROM shop_users WHERE user_id=1")
+    row = cur.fetchone()
+    assert row and row[0] == 1
+    conn.close()


### PR DESCRIPTION
## Summary
- track user shop in new `shop_users` table
- register users on every interaction
- limit broadcast to users of the selected shop
- include migration helper and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e061d2ed8833388ec687922939176