### PR TITLE
Limit Respuestas config to super admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ellos se incluyen **💬 Respuestas**, **📦 Surtido**, **➕ Producto**, **�
 En **💬 Respuestas** puedes definir distintos textos que el bot enviará. Se añadió la opción
 **Agregar/Cambiar mensaje de entrega manual**, utilizado cuando un producto requiere
 entrega manual. En ese mensaje puedes incluir las palabras `username` y `name` para
-personalizarlo.
+personalizarlo. Configurar **💬 Respuestas** es un privilegio exclusivo del super admin.
 
 ### Carga y edición de unidades
 

--- a/adminka.py
+++ b/adminka.py
@@ -80,7 +80,8 @@ def in_adminka(chat_id, message_text, username, name_user):
                 with shelve.open(files.sost_bd) as bd:
                     del bd[str(chat_id)]
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
-            user_markup.row('💬 Respuestas')
+            if chat_id == config.admin_id:
+                user_markup.row('💬 Respuestas')
             user_markup.row('📦 Surtido', '➕ Producto')
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
@@ -91,7 +92,10 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, '¡Has ingresado al panel de administración del bot!\nPara salir, presiona /start', reply_markup=user_markup)
 
         elif message_text == '💬 Respuestas':
-            if dop.check_message('start') is True: 
+            if chat_id != config.admin_id:
+                bot.send_message(chat_id, '❌ Solo el super admin puede modificar las respuestas.')
+                return
+            if dop.check_message('start') is True:
                 start = 'Cambiar'
             else: 
                 start = 'Añadir'
@@ -720,7 +724,8 @@ def text_analytics(message_text, chat_id):
                     success = False
             if success:
                 user_markup = telebot.types.ReplyKeyboardMarkup(True, True)
-                user_markup.row('💬 Respuestas')
+                if chat_id == config.admin_id:
+                    user_markup.row('💬 Respuestas')
                 user_markup.row('📦 Surtido', '➕ Producto')
                 user_markup.row('💰 Pagos')
                 user_markup.row('📊 Stats', '📣 Difusión')
@@ -1735,7 +1740,8 @@ def ad_inline(callback_data, chat_id, message_id):
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
         user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
-        user_markup.row('💬 Respuestas')
+        if chat_id == config.admin_id:
+            user_markup.row('💬 Respuestas')
         user_markup.row('📦 Surtido', '➕ Producto')
         user_markup.row('💰 Pagos')
         user_markup.row('📊 Stats', '📣 Difusión')

--- a/adminka_minimal.py
+++ b/adminka_minimal.py
@@ -13,7 +13,8 @@ def in_adminka(chat_id, message_text, username, name_user):
                         del bd[str(chat_id)]
             
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
-            user_markup.row('💬 Respuestas')
+            if chat_id == config.admin_id:
+                user_markup.row('💬 Respuestas')
             user_markup.row('📦 Surtido', '➕ Producto')
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
@@ -21,6 +22,12 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, '¡Panel de administración!\nPara salir: /start', reply_markup=user_markup)
 
         
+        elif message_text == '💬 Respuestas':
+            if chat_id != config.admin_id:
+                bot.send_message(chat_id, '❌ Solo el super admin puede modificar las respuestas.')
+                return
+            bot.send_message(chat_id, 'Función no disponible en esta versión.')
+
         elif message_text == '📊 Stats':
             try:
                 result = dop.get_daily_sales()
@@ -68,7 +75,8 @@ def ad_inline(callback_data, chat_id, message_id):
                     del bd[str(chat_id)]
         
         user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
-        user_markup.row('💬 Respuestas')
+        if chat_id == config.admin_id:
+            user_markup.row('💬 Respuestas')
         user_markup.row('📦 Surtido', '➕ Producto')
         user_markup.row('💰 Pagos')
         user_markup.row('⚙️ Otros')


### PR DESCRIPTION
## Summary
- super admin only sees and can manage **💬 Respuestas**
- mention the privilege in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e105ddcfc8333930dfec034abebb9