### PR TITLE
Add manual campaign group selection

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -611,10 +611,29 @@ def in_adminka(chat_id, message_text, username, name_user):
             else:
                 try:
                     camp_id = int(params.split()[0])
-                    ok, msg = advertising.send_campaign_now(camp_id)
-                    bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
                 except ValueError:
                     bot.send_message(chat_id, '❌ ID de campaña inválido')
+                    return
+
+                groups = advertising.get_target_groups()
+                if not groups:
+                    bot.send_message(chat_id, 'No hay grupos activos registrados.')
+                    return
+
+                markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                for g in groups:
+                    title = g['group_name'] or g['group_id']
+                    markup.row(f"{title} ({g['group_id']})")
+                markup.row('Cancelar')
+
+                os.makedirs('data/Temp', exist_ok=True)
+                tmp = f'data/Temp/{chat_id}_manual_send.json'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    json.dump({'camp_id': camp_id, 'groups': groups}, f)
+
+                bot.send_message(chat_id, 'Seleccione el grupo destino:', reply_markup=markup)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 176
 
 
         elif 'Vista previa' == message_text:
@@ -1766,6 +1785,39 @@ def text_analytics(message_text, chat_id):
             bot.send_message(chat_id, '✅ Configuración de Telegram actualizada')
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
+
+        elif sost_num == 176:  # Envío manual a grupo
+            tmp = f'data/Temp/{chat_id}_manual_send.json'
+            if message_text == 'Cancelar':
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                in_adminka(chat_id, '📢 Marketing', None, None)
+            else:
+                try:
+                    with open(tmp, 'r', encoding='utf-8') as f:
+                        data = json.load(f)
+                except FileNotFoundError:
+                    session_expired(chat_id)
+                    return
+                camp_id = data['camp_id']
+                groups = data['groups']
+                key = f"{message_text}"
+                selected = next(
+                    (g for g in groups if f"{g['group_name'] or g['group_id']} ({g['group_id']})" == key),
+                    None
+                )
+                if not selected:
+                    bot.send_message(chat_id, 'Selección inválida. Intente nuevamente.')
+                    return
+                ok, msg = advertising.send_campaign_to_group(camp_id, selected['group_id'])
+                bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                in_adminka(chat_id, '📢 Marketing', None, None)
 
 
 def ad_inline(callback_data, chat_id, message_id):

--- a/advertising_system/ad_manager.py
+++ b/advertising_system/ad_manager.py
@@ -195,6 +195,23 @@ class AdvertisingManager:
             return True, 'Grupo eliminado'
         return False, 'Grupo no encontrado'
 
+    def get_target_groups(self, platform='telegram'):
+        """Obtener grupos activos registrados para una plataforma."""
+        conn, shared = self._get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """SELECT id, group_id, group_name FROM target_groups
+               WHERE platform = ? AND status = 'active' AND shop_id = ?""",
+            (platform, self.shop_id),
+        )
+        rows = cur.fetchall()
+        if not shared:
+            conn.close()
+        return [
+            {'id': r[0], 'group_id': r[1], 'group_name': r[2]}
+            for r in rows
+        ]
+
     def get_platform_configs(self):
         """Obtener la configuración de plataformas."""
         conn, shared = self._get_connection()

--- a/tests/test_advertising.py
+++ b/tests/test_advertising.py
@@ -266,3 +266,21 @@ def test_send_campaign_to_group_fails(tmp_path, monkeypatch):
 
     assert rows == [("failed", "err", 1)]
 
+
+def test_get_target_groups_only_active(tmp_path):
+    db_path = tmp_path / "ads.db"
+    init_ads_db(db_path)
+    manager = AdvertisingManager(str(db_path))
+
+    manager.add_target_group("telegram", "111", "GroupA")
+    manager.add_target_group("telegram", "222", "GroupB")
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("UPDATE target_groups SET status='blocked' WHERE group_id='222'")
+    conn.commit()
+    conn.close()
+
+    groups = manager.get_target_groups()
+    assert groups == [{"id": 1, "group_id": "111", "group_name": "GroupA"}]
+


### PR DESCRIPTION
## Summary
- implement `AdvertisingManager.get_target_groups`
- allow choosing a target group when using "Envío manual"
- handle sending to the selected group in a new state
- test active group retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e919a27e48333bb38221041210f88