### PR TITLE
Add shop information fields and features

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -672,6 +672,9 @@ def in_adminka(chat_id, message_text, username, name_user):
             if chat_id == config.admin_id:
                 user_markup.row('Añadir nuevo admin', 'Eliminar admin')
             user_markup.row('Cambiar nombre de tienda')
+            user_markup.row('Cambiar descripción de tienda')
+            user_markup.row('Cambiar multimedia de tienda')
+            user_markup.row('Cambiar botones de tienda')
             if chat_id == config.admin_id:
                 user_markup.row('🛍️ Gestionar tiendas')
             user_markup.row('Volver al menú principal')
@@ -709,6 +712,21 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, 'Ingrese el nuevo nombre de la tienda:')
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 303
+
+        elif message_text == 'Cambiar descripción de tienda':
+            bot.send_message(chat_id, 'Ingrese la nueva descripción (o "ELIMINAR" para borrar):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 304
+
+        elif message_text == 'Cambiar multimedia de tienda':
+            bot.send_message(chat_id, 'Envía una foto o video para la tienda o escribe "ELIMINAR"')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 305
+
+        elif message_text == 'Cambiar botones de tienda':
+            bot.send_message(chat_id, 'Texto para el primer botón (o "ninguno"):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 306
 
         elif message_text == '🛍️ Gestionar tiendas' and chat_id == config.admin_id:
             shops = dop.list_shops()
@@ -1388,6 +1406,70 @@ def text_analytics(message_text, chat_id):
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
 
+        elif sost_num == 304:
+            shop_id = dop.get_shop_id(chat_id)
+            desc = '' if message_text.upper() == 'ELIMINAR' else message_text
+            dop.update_shop_info(shop_id, description=desc)
+            bot.send_message(chat_id, 'Descripción actualizada.')
+            in_adminka(chat_id, '⚙️ Otros', None, None)
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+
+        elif sost_num == 305:
+            if message_text.upper() == 'ELIMINAR':
+                shop_id = dop.get_shop_id(chat_id)
+                dop.update_shop_info(shop_id, media_file_id=None, media_type=None)
+                bot.send_message(chat_id, 'Multimedia eliminada.')
+                in_adminka(chat_id, '⚙️ Otros', None, None)
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+            else:
+                bot.send_message(chat_id, 'Envía una foto o video o escribe ELIMINAR.')
+
+        elif sost_num == 306:
+            with open(f'data/Temp/{chat_id}_shop_buttons.txt', 'w', encoding='utf-8') as f:
+                f.write(('' if message_text.lower() == 'ninguno' else message_text) + '\n')
+            bot.send_message(chat_id, 'URL del primer botón (o "ninguno"):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 307
+
+        elif sost_num == 307:
+            path = f'data/Temp/{chat_id}_shop_buttons.txt'
+            with open(path, 'a', encoding='utf-8') as f:
+                f.write(('' if message_text.lower() == 'ninguno' else message_text) + '\n')
+            bot.send_message(chat_id, 'Texto del segundo botón (o "ninguno"):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 308
+
+        elif sost_num == 308:
+            path = f'data/Temp/{chat_id}_shop_buttons.txt'
+            with open(path, 'a', encoding='utf-8') as f:
+                f.write(('' if message_text.lower() == 'ninguno' else message_text) + '\n')
+            bot.send_message(chat_id, 'URL del segundo botón (o "ninguno"):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 309
+
+        elif sost_num == 309:
+            path = f'data/Temp/{chat_id}_shop_buttons.txt'
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    b1_text = f.readline().rstrip('\n')
+                    b1_url = f.readline().rstrip('\n')
+                    b2_text = f.readline().rstrip('\n')
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            b2_url = '' if message_text.lower() == 'ninguno' else message_text
+            shop_id = dop.get_shop_id(chat_id)
+            dop.update_shop_info(shop_id,
+                                button1_text=b1_text, button1_url=b1_url,
+                                button2_text=b2_text, button2_url=b2_url)
+            bot.send_message(chat_id, 'Botones actualizados.')
+            in_adminka(chat_id, '⚙️ Otros', None, None)
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            os.remove(path)
+
         elif sost_num == 21:
             if chat_id != config.admin_id:
                 bot.send_message(chat_id, '❌ No tiene permiso para agregar administradores.')
@@ -2029,7 +2111,7 @@ def handle_multimedia(message):
         with shelve.open(files.sost_bd) as bd:
             state = bd.get(str(chat_id))
 
-        if state not in (32, 200, 42, 162, 165):
+        if state not in (32, 200, 42, 162, 165, 305):
             return
 
         if state == 32:
@@ -2040,6 +2122,8 @@ def handle_multimedia(message):
             temp_path = None
             media_path = f'data/Temp/{chat_id}_campaign_media.txt'
         elif state == 165:
+            temp_path = None
+        elif state == 305:
             temp_path = None
         else:
             temp_path = 'data/Temp/' + str(chat_id) + 'new_media.txt'
@@ -2137,6 +2221,13 @@ def handle_multimedia(message):
                 bot.send_message(chat_id, 'Si deseas agregar un botón escribe:\n<texto> <url>\nEscribe "no" para continuar sin botones:')
                 with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 166
+                return
+            elif state == 305:
+                dop.update_shop_info(shop_id, media_file_id=file_id, media_type=media_type)
+                bot.send_message(chat_id, 'Multimedia de tienda actualizada.')
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                in_adminka(chat_id, '⚙️ Otros', None, None)
                 return
             else:
                 with open('data/Temp/' + str(chat_id) + 'new_media.txt', 'w', encoding='utf-8') as f:

--- a/dop.py
+++ b/dop.py
@@ -22,10 +22,34 @@ def ensure_database_schema():
             CREATE TABLE IF NOT EXISTS shops (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 admin_id INTEGER,
-                name TEXT UNIQUE NOT NULL
+                name TEXT UNIQUE NOT NULL,
+                description TEXT,
+                media_file_id TEXT,
+                media_type TEXT,
+                button1_text TEXT,
+                button1_url TEXT,
+                button2_text TEXT,
+                button2_url TEXT
             )
             """
         )
+
+        cursor.execute("PRAGMA table_info(shops)")
+        shop_cols = [c[1] for c in cursor.fetchall()]
+        if 'description' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN description TEXT")
+        if 'media_file_id' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN media_file_id TEXT")
+        if 'media_type' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN media_type TEXT")
+        if 'button1_text' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN button1_text TEXT")
+        if 'button1_url' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN button1_url TEXT")
+        if 'button2_text' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN button2_text TEXT")
+        if 'button2_url' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN button2_url TEXT")
 
         cursor.execute("PRAGMA table_info(categories)")
         cat_cols = [c[1] for c in cursor.fetchall()]
@@ -756,6 +780,74 @@ def update_shop_name(shop_id, new_name):
     except Exception as e:
         print(f"Error actualizando nombre de tienda: {e}")
         return False
+
+def update_shop_info(shop_id, description=None, media_file_id=None, media_type=None,
+                     button1_text=None, button1_url=None, button2_text=None, button2_url=None):
+    """Actualizar campos de información de una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        updates = []
+        params = []
+        if description is not None:
+            updates.append("description = ?")
+            params.append(description)
+        if media_file_id is not None:
+            updates.append("media_file_id = ?")
+            params.append(media_file_id)
+        if media_type is not None:
+            updates.append("media_type = ?")
+            params.append(media_type)
+        if button1_text is not None:
+            updates.append("button1_text = ?")
+            params.append(button1_text)
+        if button1_url is not None:
+            updates.append("button1_url = ?")
+            params.append(button1_url)
+        if button2_text is not None:
+            updates.append("button2_text = ?")
+            params.append(button2_text)
+        if button2_url is not None:
+            updates.append("button2_url = ?")
+            params.append(button2_url)
+        if not updates:
+            return False
+        params.append(shop_id)
+        cur.execute(f"UPDATE shops SET {', '.join(updates)} WHERE id = ?", params)
+        con.commit()
+        return cur.rowcount > 0
+    except Exception as e:
+        print(f"Error actualizando información de tienda: {e}")
+        return False
+
+def get_shop_info(shop_id):
+    """Obtener descripción, multimedia y botones de una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            """
+            SELECT description, media_file_id, media_type,
+                   button1_text, button1_url, button2_text, button2_url
+            FROM shops WHERE id = ?
+            """,
+            (shop_id,),
+        )
+        row = cur.fetchone()
+        if row:
+            return {
+                'description': row[0],
+                'media_file_id': row[1],
+                'media_type': row[2],
+                'button1_text': row[3],
+                'button1_url': row[4],
+                'button2_text': row[5],
+                'button2_url': row[6],
+            }
+        return None
+    except Exception as e:
+        print(f"Error obteniendo información de tienda: {e}")
+        return None
 
 # ------------------------------------------------------------------
 # Funciones para la tienda seleccionada por cada usuario

--- a/init_db.py
+++ b/init_db.py
@@ -28,7 +28,14 @@ def create_database():
         CREATE TABLE IF NOT EXISTS shops (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             admin_id INTEGER,
-            name TEXT UNIQUE NOT NULL
+            name TEXT UNIQUE NOT NULL,
+            description TEXT,
+            media_file_id TEXT,
+            media_type TEXT,
+            button1_text TEXT,
+            button1_url TEXT,
+            button2_text TEXT,
+            button2_url TEXT
         )
     ''')
     print("✓ Tabla 'shops' creada")

--- a/main.py
+++ b/main.py
@@ -245,6 +245,29 @@ def inline(callback):
         elif callback.data.startswith('SELECT_SHOP_'):
             shop_id = int(callback.data.replace('SELECT_SHOP_', ''))
             dop.set_user_shop(callback.message.chat.id, shop_id)
+            info = dop.get_shop_info(shop_id)
+            if info and (info.get('description') or info.get('media_file_id')):
+                markup = telebot.types.InlineKeyboardMarkup()
+                if info.get('button1_text') and info.get('button1_url'):
+                    markup.add(telebot.types.InlineKeyboardButton(text=info['button1_text'], url=info['button1_url']))
+                if info.get('button2_text') and info.get('button2_url'):
+                    markup.add(telebot.types.InlineKeyboardButton(text=info['button2_text'], url=info['button2_url']))
+                if info.get('media_file_id'):
+                    if info.get('media_type') == 'photo':
+                        bot.send_photo(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                    elif info.get('media_type') == 'video':
+                        bot.send_video(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                    elif info.get('media_type') == 'document':
+                        bot.send_document(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                    elif info.get('media_type') == 'audio':
+                        bot.send_audio(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                    elif info.get('media_type') == 'animation':
+                        bot.send_animation(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                    else:
+                        bot.send_message(callback.message.chat.id, info.get('description') or '', reply_markup=markup)
+                else:
+                    bot.send_message(callback.message.chat.id, info.get('description'), reply_markup=markup)
+
             con = dop.get_db_connection() if hasattr(dop, 'get_db_connection') else db.get_db_connection()
             cursor = con.cursor()
             cursor.execute("SELECT name, price FROM goods WHERE shop_id = ?;", (shop_id,))
@@ -256,11 +279,11 @@ def inline(callback):
                 bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='📭 No hay productos disponibles en este momento')
             else:
                 catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog(shop_id)}"
+                bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
                 if callback.message.content_type != 'text':
                     bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                    bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
                 else:
-                    dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
+                    pass
 
         elif callback.data == 'Ir al catálogo de productos':
             # Optimización: usar conexión eficiente

--- a/migrate_add_shop_info.py
+++ b/migrate_add_shop_info.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Add description and media/button fields to shops table."""
+import db
+
+
+def main():
+    conn = db.get_db_connection()
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(shops)")
+    cols = [c[1] for c in cur.fetchall()]
+    mappings = [
+        ("description", "TEXT"),
+        ("media_file_id", "TEXT"),
+        ("media_type", "TEXT"),
+        ("button1_text", "TEXT"),
+        ("button1_url", "TEXT"),
+        ("button2_text", "TEXT"),
+        ("button2_url", "TEXT"),
+    ]
+    for col, ctype in mappings:
+        if col not in cols:
+            cur.execute(f"ALTER TABLE shops ADD COLUMN {col} {ctype}")
+            print(f"✓ Columna '{col}' agregada a 'shops'")
+        else:
+            print(f"ℹ️ La tabla 'shops' ya tiene '{col}'")
+    conn.commit()
+    print("✓ Migración completada")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -1,0 +1,116 @@
+import importlib, sqlite3, sys, types, os
+from pathlib import Path
+
+
+def setup_main(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+    sys.modules.setdefault(
+        "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+    )
+
+    calls = []
+
+    class Bot:
+        def message_handler(self, *a, **k):
+            def wrapper(f):
+                return f
+            return wrapper
+        def callback_query_handler(self, *a, **k):
+            def wrapper(f):
+                return f
+            return wrapper
+        def send_message(self, *a, **k):
+            calls.append(("send_message", a, k))
+        def send_photo(self, *a, **k):
+            calls.append(("send_photo", a, k))
+        def send_video(self, *a, **k):
+            calls.append(("send_video", a, k))
+        def send_document(self, *a, **k):
+            calls.append(("send_document", a, k))
+        def send_audio(self, *a, **k):
+            calls.append(("send_audio", a, k))
+        def send_animation(self, *a, **k):
+            calls.append(("send_animation", a, k))
+        def delete_message(self, *a, **k):
+            calls.append(("delete_message", a, k))
+
+    class Markup:
+        def __init__(self):
+            self.buttons = []
+        def add(self, *btns):
+            self.buttons.extend(btns)
+
+    class Button:
+        def __init__(self, text, callback_data=None, url=None):
+            self.text = text
+            self.callback_data = callback_data
+            self.url = url
+
+    telebot_stub = types.SimpleNamespace(TeleBot=lambda *a, **k: Bot(),
+                                         types=types.SimpleNamespace(
+                                             InlineKeyboardMarkup=Markup,
+                                             InlineKeyboardButton=Button))
+    sys.modules["telebot"] = telebot_stub
+    bot = telebot_stub.TeleBot()
+    sys.modules["bot_instance"] = types.SimpleNamespace(bot=bot)
+    sys.modules.setdefault(
+        "requests", types.SimpleNamespace(post=lambda *a, **k: None, get=lambda *a, **k: None)
+    )
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    import files
+    monkeypatch.setattr(files, "main_db", str(tmp_path / "main.db"))
+
+    os.makedirs("data/db", exist_ok=True)
+    open("data/db/main_data.db", "w").close()
+
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE shops (id INTEGER PRIMARY KEY AUTOINCREMENT, admin_id INTEGER, name TEXT)")
+    cur.execute("CREATE TABLE goods (name TEXT PRIMARY KEY, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    sys.modules.pop("db", None)
+    sys.modules.pop("dop", None)
+    sys.modules.pop("main", None)
+    dop = importlib.import_module("dop")
+    main = importlib.import_module("main")
+
+    return dop, main, calls, bot
+
+
+def test_shop_info_storage(monkeypatch, tmp_path):
+    dop, _, _, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.update_shop_info(sid, description="desc", media_file_id="fid", media_type="photo", button1_text="B1", button1_url="u1")
+    info = dop.get_shop_info(sid)
+    assert info["description"] == "desc"
+    assert info["media_file_id"] == "fid"
+    assert info["media_type"] == "photo"
+    assert info["button1_text"] == "B1"
+    assert info["button1_url"] == "u1"
+
+
+def test_shop_selection_shows_info(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.create_product("P", "d", "txt", 1, 2, "x", shop_id=sid)
+    dop.update_shop_info(sid, description="desc", media_file_id="fid", media_type="photo", button1_text="B1", button1_url="u1")
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5)
+            self.message_id = 1
+            self.content_type = "text"
+            self.from_user = types.SimpleNamespace(first_name="a")
+    cb = types.SimpleNamespace(data=f"SELECT_SHOP_{sid}", message=Msg(), id="1", from_user=types.SimpleNamespace(username="u"))
+    main.inline(cb)
+    assert any(c[0] == "send_photo" for c in calls)
+    assert any("CATÁLOGO" in c[1][1] for c in calls if c[0] == "send_message")


### PR DESCRIPTION
## Summary
- extend `shops` schema with description, media and button fields
- migration script for updating existing databases
- functions `update_shop_info` and `get_shop_info` in dop
- allow admins to configure shop info via adminka
- display shop info when users select a shop
- tests for storing and showing shop information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea2d2c9d08333b0d1040d2f7701ef