### PR TITLE
Fix start.bat formatting

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,2 +1,4 @@
 title BOT
-py main.pypause
+py main.py
+pause
+pause


### PR DESCRIPTION
## Summary
- ensure each command in `start.bat` is on its own line

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686eb8398144833399d29a469ee825bc