### PR TITLE
Update goods table indexing and file paths

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1278,7 +1278,7 @@ def text_analytics(message_text, chat_id):
                 return
 
             action = message_text.strip().lower()
-            file_path = f'data/goods/{product}.txt'
+            file_path = f'data/goods/{shop_id}_{product}.txt'
             if action == 'añadir unidades':
                 bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
                 with shelve.open(files.sost_bd) as bd:
@@ -1319,7 +1319,7 @@ def text_analytics(message_text, chat_id):
             except FileNotFoundError:
                 session_expired(chat_id)
                 return
-            file_path = f'data/goods/{product}.txt'
+            file_path = f'data/goods/{shop_id}_{product}.txt'
             with open(file_path, 'a', encoding='utf-8') as f:
                 f.write(message_text + '\n')
             bot.send_message(chat_id, '¡Unidades añadidas con éxito!')
@@ -1334,7 +1334,7 @@ def text_analytics(message_text, chat_id):
             except FileNotFoundError:
                 session_expired(chat_id)
                 return
-            file_path = f'data/goods/{product}.txt'
+            file_path = f'data/goods/{shop_id}_{product}.txt'
             if not os.path.exists(file_path):
                 bot.send_message(chat_id, '❌ Archivo de producto no encontrado')
                 show_product_menu(chat_id)
@@ -1367,7 +1367,7 @@ def text_analytics(message_text, chat_id):
             except FileNotFoundError:
                 session_expired(chat_id)
                 return
-            file_path = f'data/goods/{product}.txt'
+            file_path = f'data/goods/{shop_id}_{product}.txt'
             if not os.path.exists(file_path):
                 bot.send_message(chat_id, '❌ Archivo de producto no encontrado')
                 show_product_menu(chat_id)
@@ -2221,7 +2221,7 @@ def ad_inline(callback_data, chat_id, message_id):
             format_type,
             minimum,
             price,
-            'data/goods/' + name + '.txt',
+            f'data/goods/{shop_id}_{name}.txt',
             additional_description='',
             media_file_id=media_id,
             media_type=media_type,
@@ -2231,7 +2231,7 @@ def ad_inline(callback_data, chat_id, message_id):
             category_id=category_id,
             shop_id=shop_id,
         )
-        goods_file = f"data/goods/{name}.txt"
+        goods_file = f"data/goods/{shop_id}_{name}.txt"
         open(goods_file, "a", encoding="utf-8").close()
         # Mostrar información del producto con la multimedia que se haya adjuntado
         media_info = dop.get_product_media(name, shop_id)

--- a/dop.py
+++ b/dop.py
@@ -740,7 +740,7 @@ def get_shop_id(admin_id):
         return cur.lastrowid
     except Exception as e:
         print(f"Error obteniendo shop_id: {e}")
-        return 1
+        return None
 
 def list_shops():
     """Listar todas las tiendas registradas."""

--- a/init_db.py
+++ b/init_db.py
@@ -53,7 +53,7 @@ def create_database():
     # Crear tabla de productos
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS goods (
-            name TEXT PRIMARY KEY,
+            name TEXT,
             description TEXT,
             format TEXT,
             minimum INTEGER,
@@ -67,6 +67,7 @@ def create_database():
             manual_delivery INTEGER DEFAULT 0,
             category_id INTEGER,
             shop_id INTEGER DEFAULT 1,
+            PRIMARY KEY (name, shop_id),
             FOREIGN KEY (category_id) REFERENCES categories(id)
         )
     ''')

--- a/migrate_goods_unique_pair.py
+++ b/migrate_goods_unique_pair.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Migrate goods table to have (name, shop_id) as primary key and update stored file paths."""
+import os
+import sqlite3
+import db
+
+
+def main():
+    conn = db.get_db_connection()
+    cur = conn.cursor()
+
+    # Check if table already migrated
+    cur.execute("PRAGMA table_info(goods)")
+    cols = cur.fetchall()
+    pk_cols = [c[1] for c in cols if c[-1]]
+    if set(pk_cols) == {"name", "shop_id"}:
+        print("ℹ️ La tabla 'goods' ya usa (name, shop_id) como clave primaria")
+        return
+
+    # Ensure shop_id column exists
+    if not any(c[1] == "shop_id" for c in cols):
+        cur.execute("ALTER TABLE goods ADD COLUMN shop_id INTEGER DEFAULT 1")
+        print("✓ Columna 'shop_id' agregada a 'goods'")
+
+    # Rename old table
+    cur.execute("ALTER TABLE goods RENAME TO goods_old")
+
+    # Create new table with composite primary key
+    cur.execute(
+        """
+        CREATE TABLE goods (
+            name TEXT,
+            description TEXT,
+            format TEXT,
+            minimum INTEGER,
+            price INTEGER,
+            stored TEXT,
+            additional_description TEXT DEFAULT '',
+            media_file_id TEXT,
+            media_type TEXT,
+            media_caption TEXT,
+            duration_days INTEGER DEFAULT NULL,
+            manual_delivery INTEGER DEFAULT 0,
+            category_id INTEGER,
+            shop_id INTEGER DEFAULT 1,
+            PRIMARY KEY (name, shop_id)
+        )
+        """
+    )
+
+    cur.execute(
+        "INSERT INTO goods SELECT name, description, format, minimum, price, stored,"
+        " additional_description, media_file_id, media_type, media_caption,"
+        " duration_days, manual_delivery, category_id, shop_id FROM goods_old"
+    )
+
+    # Move stored files
+    cur.execute("SELECT name, stored, shop_id FROM goods")
+    rows = cur.fetchall()
+    for name, stored, shop_id in rows:
+        if not stored:
+            continue
+        prefix = f"data/goods/{shop_id}_"
+        desired = f"{prefix}{name}.txt"
+        if stored != desired and os.path.exists(stored):
+            os.makedirs(os.path.dirname(desired), exist_ok=True)
+            os.rename(stored, desired)
+            cur.execute(
+                "UPDATE goods SET stored = ? WHERE name = ? AND shop_id = ?",
+                (desired, name, shop_id),
+            )
+
+    conn.commit()
+    cur.execute("DROP TABLE goods_old")
+    conn.commit()
+    print("✓ Migración completada")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -29,7 +29,9 @@ def setup_dop(monkeypatch, tmp_path):
     conn = sqlite3.connect(files.main_db)
     cur = conn.cursor()
     cur.execute("CREATE TABLE shops (id INTEGER PRIMARY KEY AUTOINCREMENT, admin_id INTEGER, name TEXT)")
-    cur.execute("CREATE TABLE goods (name TEXT PRIMARY KEY, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER)")
+    cur.execute(
+        "CREATE TABLE goods (name TEXT, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER DEFAULT 1, PRIMARY KEY (name, shop_id))"
+    )
     conn.commit()
     conn.close()
 

--- a/tests/test_goods_isolation.py
+++ b/tests/test_goods_isolation.py
@@ -1,0 +1,19 @@
+import sqlite3
+from tests.test_categories import setup_dop
+
+
+def test_same_product_name_different_shops(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    assert dop.create_shop("S1", admin_id=1) == 1
+    assert dop.create_shop("S2", admin_id=2) == 2
+
+    ok1 = dop.create_product("Prod", "d1", "txt", 1, 5, "f1", shop_id=1)
+    ok2 = dop.create_product("Prod", "d2", "txt", 1, 10, "f2", shop_id=2)
+    assert ok1 and ok2
+
+    desc1 = dop.get_description("Prod", 1)
+    desc2 = dop.get_description("Prod", 2)
+    assert "d1" in desc1
+    assert "d2" in desc2

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -71,7 +71,9 @@ def setup_main(monkeypatch, tmp_path):
     conn = sqlite3.connect(files.main_db)
     cur = conn.cursor()
     cur.execute("CREATE TABLE shops (id INTEGER PRIMARY KEY AUTOINCREMENT, admin_id INTEGER, name TEXT)")
-    cur.execute("CREATE TABLE goods (name TEXT PRIMARY KEY, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER)")
+    cur.execute(
+        "CREATE TABLE goods (name TEXT, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER DEFAULT 1, PRIMARY KEY (name, shop_id))"
+    )
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- enforce `(name, shop_id)` as the primary key of `goods`
- store product stock files using `shop_id` in the filename
- migrate old `goods` entries and their files
- avoid returning shop 1 on `get_shop_id` errors
- test that same product name works in separate shops

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed5164fc08333b19152c474555e2d