### PR TITLE
Add category selection to product catalog

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -316,6 +316,26 @@ def get_goods(shop_id=1):
     except:
         return []
 
+def list_products_by_category(cat_id=None, shop_id=1):
+    """Return product names filtered by category for a shop."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        if cat_id is None:
+            cursor.execute(
+                "SELECT name FROM goods WHERE shop_id = ?;",
+                (shop_id,)
+            )
+        else:
+            cursor.execute(
+                "SELECT name FROM goods WHERE shop_id = ? AND category_id = ?;",
+                (shop_id, cat_id),
+            )
+        return [row[0] for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"Error listando productos por categoría: {e}")
+        return []
+
 def list_categories(shop_id=1):
     """Devuelve lista de categorías (id, nombre)."""
     try:

--- a/main.py
+++ b/main.py
@@ -269,22 +269,20 @@ def inline(callback):
                 else:
                     bot.send_message(callback.message.chat.id, info.get('description'), reply_markup=markup)
 
-            con = dop.get_db_connection() if hasattr(dop, 'get_db_connection') else db.get_db_connection()
-            cursor = con.cursor()
-            cursor.execute("SELECT name, price FROM goods WHERE shop_id = ?;", (shop_id,))
+            categories = dop.list_categories(shop_id)
             key = telebot.types.InlineKeyboardMarkup()
-            for name, price in cursor.fetchall():
-                key.add(telebot.types.InlineKeyboardButton(text=f'📦 {name}', callback_data=name))
+            for cid, cname in categories:
+                key.add(telebot.types.InlineKeyboardButton(text=cname, callback_data=f'CAT_{cid}'))
+            key.add(telebot.types.InlineKeyboardButton(text='Todos los productos', callback_data='CAT_NONE'))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
-            if dop.get_productcatalog(shop_id) is None:
-                bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='📭 No hay productos disponibles en este momento')
-            else:
-                catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog(shop_id)}"
-                bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
-                if callback.message.content_type != 'text':
-                    bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                else:
-                    pass
+            bot.send_message(
+                callback.message.chat.id,
+                '📂 **SELECCIONA UNA CATEGORÍA**',
+                reply_markup=key,
+                parse_mode='Markdown'
+            )
+            if callback.message.content_type != 'text':
+                bot.delete_message(callback.message.chat.id, callback.message.message_id)
 
         elif callback.data == 'Ir al catálogo de productos':
             # Optimización: usar conexión eficiente
@@ -300,6 +298,25 @@ def inline(callback):
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
 
             if dop.get_productcatalog(shop_id_cb) == None:
+                bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='📭 No hay productos disponibles en este momento')
+            else:
+                catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog(shop_id_cb)}"
+                if callback.message.content_type != 'text':
+                    bot.delete_message(callback.message.chat.id, callback.message.message_id)
+                    bot.send_message(callback.message.chat.id, catalog_text, reply_markup=key, parse_mode='Markdown')
+                else:
+                    dop.safe_edit_message(bot, callback.message, catalog_text, reply_markup=key, parse_mode='Markdown')
+
+        elif callback.data.startswith('CAT_'):
+            raw = callback.data.replace('CAT_', '')
+            cat_id = None if raw == 'NONE' else int(raw)
+            goods = dop.list_products_by_category(cat_id, shop_id_cb)
+            key = telebot.types.InlineKeyboardMarkup()
+            for name in goods:
+                key.add(telebot.types.InlineKeyboardButton(text=f'📦 {name}', callback_data=name))
+            key.add(telebot.types.InlineKeyboardButton(text='🔙 Categorías', callback_data=f'SELECT_SHOP_{shop_id_cb}'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            if dop.get_productcatalog(shop_id_cb) is None or not goods:
                 bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='📭 No hay productos disponibles en este momento')
             else:
                 catalog_text = f"🛍️ **CATÁLOGO DE PRODUCTOS**\n{'-'*30}\n\n{dop.get_productcatalog(shop_id_cb)}"

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -115,4 +115,41 @@ def test_shop_selection_shows_info(monkeypatch, tmp_path):
     cb = types.SimpleNamespace(data=f"SELECT_SHOP_{sid}", message=Msg(), id="1", from_user=types.SimpleNamespace(username="u"))
     main.inline(cb)
     assert any(c[0] == "send_photo" for c in calls)
-    assert any("CATÁLOGO" in c[1][1] for c in calls if c[0] == "send_message")
+    assert any("CATEGORÍA" in c[1][1] for c in calls if c[0] == "send_message")
+
+
+def test_category_selection_lists_products(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    cid = dop.create_category("Cat", shop_id=sid)
+    dop.create_product("P1", "d", "txt", 1, 2, "x", category_id=cid, shop_id=sid)
+    dop.create_product("P2", "d", "txt", 1, 2, "x", shop_id=sid)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5)
+            self.message_id = 1
+            self.content_type = "text"
+            self.from_user = types.SimpleNamespace(first_name="a")
+    msg = Msg()
+
+    cb_shop = types.SimpleNamespace(data=f"SELECT_SHOP_{sid}", message=msg, id="1", from_user=types.SimpleNamespace(username="u"))
+    main.inline(cb_shop)
+    calls.clear()
+
+    cb_cat = types.SimpleNamespace(data=f"CAT_{cid}", message=msg, id="2", from_user=types.SimpleNamespace(username="u"))
+    main.inline(cb_cat)
+
+    messages = [c for c in calls if c[0] == "send_message"]
+    msg_texts = []
+    for m in messages:
+        if len(m[1]) > 1:
+            msg_texts.append(m[1][1])
+        else:
+            msg_texts.append(m[2].get("text", ""))
+    assert any("CATÁLOGO" in t for t in msg_texts)
+    buttons = messages[-1][2]["reply_markup"].buttons
+    btn_texts = [b.text for b in buttons]
+    assert any("P1" in t for t in btn_texts)
+    assert not any("P2" in t for t in btn_texts)


### PR DESCRIPTION
## Summary
- add `list_products_by_category` helper in `dop.py`
- show categories after shop selection and support `CAT_<id>` callbacks
- adjust catalog flow to let users pick categories
- update shop info tests and add new test for category selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee869f84083338bfbb93356cdef34