### PR TITLE
Add discount_config table creation

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -137,6 +137,19 @@ def ensure_database_schema():
             """
         )
 
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS discount_config (
+                id INTEGER PRIMARY KEY,
+                discount_enabled INTEGER DEFAULT 1,
+                discount_text TEXT DEFAULT '🔥 DESCUENTOS ESPECIALES ACTIVOS 🔥',
+                discount_multiplier REAL DEFAULT 1.5,
+                show_fake_price INTEGER DEFAULT 1,
+                shop_id INTEGER UNIQUE
+            )
+            """
+        )
+
         if updated:
             con.commit()
         con.commit()

--- a/tests/test_discount_config_schema.py
+++ b/tests/test_discount_config_schema.py
@@ -1,0 +1,18 @@
+import sqlite3
+from tests.test_categories import setup_dop
+
+
+def test_discount_config_table_created(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='discount_config'")
+    assert cur.fetchone() is not None
+
+    cur.execute("PRAGMA table_info(discount_config)")
+    cols = [c[1] for c in cur.fetchall()]
+    expected = {"discount_enabled", "discount_text", "discount_multiplier", "show_fake_price", "shop_id"}
+    assert expected.issubset(set(cols))
+    conn.close()


### PR DESCRIPTION
## Summary
- create `discount_config` table when ensuring DB schema
- test that `discount_config` is created and has expected columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0e3b0cfc8333a56d61af9a2b3246