### PR TITLE
Add admin list cleanup test

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -258,6 +258,8 @@ def check_message(message):
 
 def get_adminlist():
     admins_list = [config.admin_id]  # Siempre incluir el admin principal
+    cleaned = []
+    dirty = False
     try:
         with open(files.admins_list, encoding='utf-8') as f:
             for admin_id in f.readlines():
@@ -265,9 +267,13 @@ def get_adminlist():
                     admin_id = int(admin_id.strip())
                     if admin_id not in admins_list:
                         admins_list.append(admin_id)
+                    cleaned.append(f"{admin_id}\n")
                 except Exception as e:
                     print(f"Error leyendo id de admin: {e}")
-                    continue
+                    dirty = True
+        if dirty:
+            with open(files.admins_list, 'w', encoding='utf-8') as f:
+                f.writelines(cleaned)
     except Exception as e:
         print(f"Error obteniendo lista de admins: {e}")
         pass

--- a/tests/test_admin_list.py
+++ b/tests/test_admin_list.py
@@ -1,0 +1,14 @@
+from tests.test_categories import setup_dop
+
+
+def test_get_adminlist_cleans_invalid(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    admins_file = tmp_path / "admins_list.txt"
+    admins_file.write_text("123\nabc\n456\n")
+    monkeypatch.setattr(dop.files, "admins_list", str(admins_file))
+
+    admins = dop.get_adminlist()
+
+    assert admins == [1, 123, 456]
+    assert admins_file.read_text().splitlines() == ["123", "456"]
+


### PR DESCRIPTION
## Summary
- ensure `get_adminlist` removes invalid ids from file
- test that invalid entries are removed and list only has numbers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1047351883338860113c5f47a022