### PR TITLE
Improve admin list handling and discount setup

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -185,6 +185,18 @@ def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
                 return False
 
 
+def clear_recent_messages(bot, chat_id, last_message_id, limit=15):
+    """Borrar los últimos mensajes en un chat."""
+    try:
+        for mid in range(last_message_id, max(last_message_id - limit, 0), -1):
+            try:
+                bot.delete_message(chat_id, mid)
+            except Exception:
+                continue
+    except Exception as e:
+        print(f"Error limpiando mensajes: {e}")
+
+
 def it_first(chat_id):
     try:
         with open(files.working_log, encoding='utf-8') as f:
@@ -227,7 +239,8 @@ def log(text):
     try:
         with open(files.working_log, 'a', encoding='utf-8') as f:
             f.write(time + '    | ' + text + '\n')
-    except Exception:
+    except Exception as e:
+        print(f"Error writing log file: {e}")
         with open(files.working_log, 'w', encoding='utf-8') as f:
             f.write(time + '    | ' + text + '\n')
 
@@ -244,19 +257,32 @@ def check_message(message):
 
 def get_adminlist():
     admins_list = [config.admin_id]  # Siempre incluir el admin principal
+    invalid_ids = []
     try:
         with open(files.admins_list, encoding='utf-8') as f:
-            for admin_id in f.readlines():
-                try:
-                    admin_id = int(admin_id.strip())
-                    if admin_id not in admins_list:
-                        admins_list.append(admin_id)
-                except Exception as e:
-                    print(f"Error leyendo id de admin: {e}")
-                    continue
+            lines = f.readlines()
+        valid_lines = []
+        for raw in lines:
+            raw = raw.strip()
+            if raw.lstrip('-').isdigit():
+                admin_id = int(raw)
+                if admin_id not in admins_list:
+                    admins_list.append(admin_id)
+                valid_lines.append(raw + "\n")
+            elif raw:
+                invalid_ids.append(raw)
+        if invalid_ids:
+            try:
+                with open(files.admins_list, 'w', encoding='utf-8') as f:
+                    f.writelines(valid_lines)
+                print(
+                    "IDs de admin inválidos eliminados: "
+                    + ", ".join(invalid_ids)
+                )
+            except Exception as e:
+                print(f"Error limpiando lista de admins: {e}")
     except Exception as e:
         print(f"Error obteniendo lista de admins: {e}")
-        pass
     return admins_list
 
 def user_loger(chat_id=0):
@@ -274,8 +300,8 @@ def user_loger(chat_id=0):
             # Registrar o actualizar la tienda del usuario
             current = get_user_shop(chat_id)
             set_user_shop(chat_id, current)
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Error updating user shop: {e}")
 
     try:
         with open(files.users_list, encoding='utf-8') as f:
@@ -703,12 +729,13 @@ def broadcast_message(group, amount, text, media=None, shop_id=1):
                     else:
                         bot.send_message(chat_id, text)
                     good_send += 1
-                except Exception:
+                except Exception as e:
                     lose_send += 1
+                    print(f"Error sending message to {chat_id}: {e}")
                     new_blockuser(chat_id)
                 i += 1
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Error sending broadcast to all users: {e}")
 
     elif group == 'buyers':
         try:
@@ -927,8 +954,8 @@ def set_user_shop(user_id, shop_id):
             (int(user_id), int(shop_id)),
         )
         con.commit()
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"Error setting user shop: {e}")
 
 
 def get_user_shop(user_id):
@@ -942,7 +969,8 @@ def get_user_shop(user_id):
         )
         row = cur.fetchone()
         return int(row[0]) if row else 1
-    except Exception:
+    except Exception as e:
+        print(f"Error getting user shop: {e}")
         return 1
 
 def get_description(name_good, shop_id=1):
@@ -1017,7 +1045,8 @@ def get_paypaldata(shop_id=1):
         if result:
             return result[0], result[1], bool(result[2])
         return None
-    except Exception:
+    except Exception as e:
+        print(f"Error getting PayPal data: {e}")
         return None
 
 def get_binancedata(shop_id=1):
@@ -1033,7 +1062,8 @@ def get_binancedata(shop_id=1):
         if result:
             return result[0], result[1], result[2]
         return None
-    except Exception:
+    except Exception as e:
+        print(f"Error getting Binance data: {e}")
         return None
 
 def save_paypaldata(client_id, client_secret, sandbox=1, shop_id=1):
@@ -1424,6 +1454,8 @@ def get_discount_config(shop_id=1):
             }
     except Exception as e:
         print(f"Error obteniendo configuración de descuentos: {e}")
+        if "no such table" in str(e):
+            setup_discount_system()
         return {
             'enabled': True,
             'text': '🔥 DESCUENTOS ESPECIALES ACTIVOS 🔥',
@@ -1493,6 +1525,11 @@ def update_discount_config(enabled=None, text=None, multiplier=None, show_fake_p
         
     except Exception as e:
         print(f"Error actualizando configuración de descuentos: {e}")
+        if "no such table" in str(e):
+            if setup_discount_system():
+                return update_discount_config(
+                    enabled, text, multiplier, show_fake_price, shop_id
+                )
         return False
 
 def setup_discount_system():
@@ -1670,7 +1707,8 @@ def get_manual_delivery_message(username, name):
     try:
         with shelve.open(files.bot_message_bd) as bd:
             text = bd.get('manual_delivery', 'Gracias por su compra, username')
-    except Exception:
+    except Exception as e:
+        print(f"Error retrieving manual delivery message: {e}")
         text = 'Gracias por su compra, username'
     text = text.replace('username', username).replace('name', name)
     return text

--- a/main.py
+++ b/main.py
@@ -57,8 +57,8 @@ def send_main_menu(chat_id, username, name):
     """Enviar el mensaje de inicio con el teclado principal"""
     key = telebot.types.InlineKeyboardMarkup()
     key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
-    key.add(telebot.types.InlineKeyboardButton(
-        text='📜 Mis compras', callback_data='Ver mis compras'))
+    key.add(telebot.types.InlineKeyboardButton(text='📜 Mis compras', callback_data='Ver mis compras'))
+    key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
     if dop.check_message('start'):
         with shelve.open(files.bot_message_bd) as bd:
             start_message = bd['start']
@@ -422,27 +422,24 @@ def inline(callback):
             dop.safe_edit_message(bot, callback.message,
                                   history, reply_markup=key, parse_mode='Markdown')
 
+        elif callback.data == 'Ver tiendas':
+            dop.clear_recent_messages(bot, callback.message.chat.id, callback.message.message_id)
+            show_shop_selection(callback.message.chat.id)
+            bot.answer_callback_query(callback.id)
 
+        
         elif callback.data == 'Volver al inicio':
             if callback.message.chat.username:
+                dop.clear_recent_messages(bot, callback.message.chat.id, callback.message.message_id)
                 if dop.get_sost(callback.message.chat.id) is True:
                     with shelve.open(files.sost_bd) as bd:
                         if str(callback.message.chat.id) in bd:
                             del bd[str(callback.message.chat.id)]
-                key = telebot.types.InlineKeyboardMarkup()
-                key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
-                key.add(telebot.types.InlineKeyboardButton(
-                    text='📜 Mis compras', callback_data='Ver mis compras'))
-                if dop.check_message('start'):
-                    with shelve.open(files.bot_message_bd) as bd:
-                        start_message = bd['start']
-                    start_message = start_message.replace('username', callback.message.chat.username)
-                    start_message = start_message.replace('name', callback.message.from_user.first_name)
-                    if callback.message.content_type != 'text':
-                        bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                        bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
-                    else:
-                        dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
+                send_main_menu(
+                    callback.message.chat.id,
+                    callback.message.chat.username,
+                    callback.message.from_user.first_name,
+                )
 
         elif callback.data == 'Comprar':
             try:

--- a/main.py
+++ b/main.py
@@ -274,6 +274,7 @@ def inline(callback):
             for cid, cname in categories:
                 key.add(telebot.types.InlineKeyboardButton(text=cname, callback_data=f'CAT_{cid}'))
             key.add(telebot.types.InlineKeyboardButton(text='Todos los productos', callback_data='CAT_NONE'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
             bot.send_message(
                 callback.message.chat.id,
@@ -289,12 +290,14 @@ def inline(callback):
             con = dop.get_db_connection() if hasattr(dop, 'get_db_connection') else db.get_db_connection()
             cursor = con.cursor()
             cursor.execute("SELECT name, price FROM goods WHERE shop_id = ?;", (shop_id_cb,))
+
             key = telebot.types.InlineKeyboardMarkup()
-            
+
             # Agregar productos con emojis
             for name, price in cursor.fetchall():
                 key.add(telebot.types.InlineKeyboardButton(text=f'📦 {name}', callback_data=name))
-            
+
+            key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
 
             if dop.get_productcatalog(shop_id_cb) == None:
@@ -315,6 +318,7 @@ def inline(callback):
             for name in goods:
                 key.add(telebot.types.InlineKeyboardButton(text=f'📦 {name}', callback_data=name))
             key.add(telebot.types.InlineKeyboardButton(text='🔙 Categorías', callback_data=f'SELECT_SHOP_{shop_id_cb}'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
             if dop.get_productcatalog(shop_id_cb) is None or not goods:
                 bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, text='📭 No hay productos disponibles en este momento')
@@ -403,6 +407,7 @@ def inline(callback):
             key.add(telebot.types.InlineKeyboardButton(text='🔙 Volver al producto', callback_data=product_name))
             key.add(telebot.types.InlineKeyboardButton(text='💰 Comprar ahora', callback_data='Comprar'))
             key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+            key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
             key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
             
             # Mostrar información adicional
@@ -416,6 +421,8 @@ def inline(callback):
         elif callback.data == 'Ver mis compras':
             history = dop.get_user_purchases(callback.message.chat.id)
             key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(
+                text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
             key.add(telebot.types.InlineKeyboardButton(
                 text='🏠 Inicio', callback_data='Volver al inicio'))
             bot.answer_callback_query(callback.id)
@@ -455,6 +462,7 @@ def inline(callback):
             else:
                 key = telebot.types.InlineKeyboardMarkup()
                 key.add(telebot.types.InlineKeyboardButton(text='🔙 Volver al producto', callback_data=name_good))
+                key.add(telebot.types.InlineKeyboardButton(text='🏬 Todas las tiendas', callback_data='Ver tiendas'))
                 key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
                 purchase_text = f"""🛒 **REALIZAR COMPRA**\n{'-'*25}\n\n📦 **Producto:** {name_good}\n\n🔢 **Ingresa la cantidad** que deseas comprar:\n\n📊 **Cantidad mínima:** {str(dop.get_minimum(name_good, shop_id_cb))} unidades\n📦 **Stock disponible:** {str(dop.amount_of_goods(name_good, shop_id_cb))} unidades\n\n💡 **Tip:** Envía solo el número (ej: 5)"""
                 dop.safe_edit_message(bot, callback.message, purchase_text, reply_markup=key, parse_mode='Markdown')

--- a/reset_data.py
+++ b/reset_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Resetear por completo la base de datos y archivos de 'data/'.
+Elimina la carpeta data/ y vuelve a ejecutar los scripts de inicialización."""
+
+import os
+import shutil
+import init_db
+import setup_advertising
+import setup_discounts
+
+
+def reset():
+    confirm = input(
+        "Esto eliminará la carpeta 'data/'. ¿Seguro que deseas continuar? (s/N): "
+    )
+    if confirm.lower() != "s":
+        print("Operación cancelada")
+        return
+
+    shutil.rmtree("data", ignore_errors=True)
+    print("🗑️ Carpeta 'data/' eliminada")
+
+    init_db.create_database()
+
+    setup_discounts.setup_discount_system()
+    setup_advertising.setup_database()
+    setup_advertising.create_directories()
+    print("✅ Sistema reiniciado")
+
+
+if __name__ == "__main__":
+    reset()


### PR DESCRIPTION
## Summary
- sanitize invalid entries when loading admin IDs
- auto-create discount configuration table on error
- add a button to change stores and clean chat on return to main menu

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ef5e832e48333a2f4d52167ea3c4d