### PR TITLE
Make TELEGRAM_ADMIN_ID mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ pip install -r requirements.txt
 4. Copia el archivo `.env.example` a `.env` (o crea uno nuevo).  El
    archivo de ejemplo incluye los campos `TELEGRAM_BOT_TOKEN`,
    `TELEGRAM_ADMIN_ID` y `TELEGRAM_TOKEN` como referencia, así que sólo
-   debes reemplazar sus valores con tus credenciales.  Si utilizarás el
+   debes reemplazar sus valores con tus credenciales.  Las variables
+   `TELEGRAM_BOT_TOKEN` y `TELEGRAM_ADMIN_ID` son obligatorias, el bot
+   fallará si no se definen. Si utilizarás el
    sistema de publicidad, **debes** definir `TELEGRAM_TOKEN` con el token
    (o los tokens separados por comas) que empleará `advertising_cron.py`;
    el script fallará si no se configura esta variable.

--- a/config.py
+++ b/config.py
@@ -5,7 +5,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Obtener valores de las variables de entorno
-admin_id = int(os.getenv('TELEGRAM_ADMIN_ID', '723745098'))
+admin_id_env = os.getenv('TELEGRAM_ADMIN_ID')
+if not admin_id_env:
+    raise RuntimeError('TELEGRAM_ADMIN_ID must be set')
+admin_id = int(admin_id_env)
 token = os.getenv('TELEGRAM_BOT_TOKEN')
 
 # Parámetros opcionales para telebot.polling


### PR DESCRIPTION
## Summary
- stop providing a default admin ID in `config.py`
- document that `TELEGRAM_ADMIN_ID` is required

## Testing
- `python -m py_compile config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686f2f1445f88333b57ac74e03320ef0