### PR TITLE
Add manual stock tracking

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -870,9 +870,9 @@ def text_analytics(message_text, chat_id):
                     f2.write('manual')
                 key = telebot.types.InlineKeyboardMarkup()
                 key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
-                bot.send_message(chat_id, 'Ahora ingrese la cantidad mínima para comprar', reply_markup=key)
+                bot.send_message(chat_id, 'Ahora ingrese la cantidad disponible en stock', reply_markup=key)
                 with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 5
+                    bd[str(chat_id)] = 12
             else:
                 user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
                 user_markup.row('En formato de texto', 'En formato de archivo')
@@ -880,6 +880,24 @@ def text_analytics(message_text, chat_id):
                 bot.send_message(chat_id, 'Ahora seleccione el formato del producto', reply_markup=user_markup)
                 with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 4
+
+        elif sost_num == 12:
+            try:
+                stock_val = int(message_text)
+                if stock_val < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, '❌ Por favor ingrese una cantidad válida (0 o más).')
+                return
+
+            with open('data/Temp/' + str(chat_id) + 'good_manual_stock.txt', 'w', encoding='utf-8') as f:
+                f.write(str(stock_val))
+
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
+            bot.send_message(chat_id, 'Ahora ingrese la cantidad mínima para comprar', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 5
 
         elif sost_num == 4:
             format_map = {
@@ -2233,6 +2251,11 @@ def ad_inline(callback_data, chat_id, message_id):
 
         if manual_flag == '1':
             format_type = 'manual'
+            try:
+                with open('data/Temp/' + str(chat_id) + 'good_manual_stock.txt', encoding='utf-8') as f:
+                    manual_stock = int(f.read())
+            except Exception:
+                manual_stock = 0
         category_id = None
         try:
             with open('data/Temp/' + str(chat_id) + 'good_category.txt', encoding='utf-8') as f:
@@ -2253,11 +2276,13 @@ def ad_inline(callback_data, chat_id, message_id):
             media_caption=media_caption,
             duration_days=duration_days,
             manual_delivery=int(manual_flag),
+            manual_stock=manual_stock if manual_flag == '1' else 0,
             category_id=category_id,
             shop_id=shop_id,
         )
         goods_file = f"data/goods/{shop_id}_{name}.txt"
-        open(goods_file, "a", encoding="utf-8").close()
+        if manual_flag != '1':
+            open(goods_file, "a", encoding="utf-8").close()
         # Mostrar información del producto con la multimedia que se haya adjuntado
         media_info = dop.get_product_media(name, shop_id)
         caption = dop.format_product_with_media(name, shop_id)
@@ -2283,6 +2308,7 @@ def ad_inline(callback_data, chat_id, message_id):
             os.remove(media_temp)
         try:
             os.remove('data/Temp/' + str(chat_id) + 'good_category.txt')
+            os.remove('data/Temp/' + str(chat_id) + 'good_manual_stock.txt')
         except Exception:
             pass
         

--- a/dop.py
+++ b/dop.py
@@ -88,6 +88,9 @@ def ensure_database_schema():
         if 'manual_delivery' not in columns:
             cursor.execute("ALTER TABLE goods ADD COLUMN manual_delivery INTEGER DEFAULT 0")
             updated = True
+        if 'manual_stock' not in columns:
+            cursor.execute("ALTER TABLE goods ADD COLUMN manual_stock INTEGER DEFAULT 0")
+            updated = True
         if 'category_id' not in columns:
             cursor.execute("ALTER TABLE goods ADD COLUMN category_id INTEGER")
             updated = True
@@ -481,9 +484,48 @@ def get_stored(name_good, shop_id=1):
         logging.error(f"Error obteniendo ruta de almacen: {e}")
         return None
 
+def get_manual_stock(name_good, shop_id=1):
+    """Return manual stock for a product."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "SELECT manual_stock FROM goods WHERE name = ? AND shop_id = ?",
+            (name_good, shop_id),
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except Exception as e:
+        logging.error(f"Error obteniendo manual_stock: {e}")
+        return 0
+
+
+def decrement_manual_stock(name_good, quantity, shop_id=1):
+    """Decrease manual stock after a purchase."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "SELECT manual_stock FROM goods WHERE name = ? AND shop_id = ?",
+            (name_good, shop_id),
+        )
+        row = cursor.fetchone()
+        current = int(row[0]) if row and row[0] is not None else 0
+        new_val = current - int(quantity)
+        if new_val < 0:
+            new_val = 0
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (new_val, name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error decrementando manual_stock: {e}")
+
+
 def amount_of_goods(name_good, shop_id=1):
     if is_manual_delivery(name_good, shop_id):
-        return 10 ** 9
+        return get_manual_stock(name_good, shop_id)
     stored = get_stored(name_good, shop_id)
     if not stored:
         return 0
@@ -1977,7 +2019,7 @@ def save_message(message_type, message_text):
 def create_product(name, description, format_type, minimum, price, stored,
                    additional_description='', media_file_id=None, media_type=None,
                    media_caption=None, duration_days=None, manual_delivery=0,
-                   category_id=None, shop_id=1):
+                   manual_stock=0, category_id=None, shop_id=1):
     """Crear un producto en la base de datos."""
     try:
         con = db.get_db_connection()
@@ -1988,14 +2030,14 @@ def create_product(name, description, format_type, minimum, price, stored,
                 name, description, format, minimum, price, stored,
                 additional_description, media_file_id, media_type,
                 media_caption, duration_days, manual_delivery,
-                category_id, shop_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                manual_stock, category_id, shop_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 name, description, format_type, minimum, price, stored,
                 additional_description, media_file_id, media_type,
                 media_caption, duration_days, manual_delivery,
-                category_id, shop_id,
+                manual_stock, category_id, shop_id,
             ),
         )
         con.commit()

--- a/init_db.py
+++ b/init_db.py
@@ -68,6 +68,7 @@ def create_database():
             media_caption TEXT,
             duration_days INTEGER DEFAULT NULL,
             manual_delivery INTEGER DEFAULT 0,
+            manual_stock INTEGER DEFAULT 0,
             category_id INTEGER,
             shop_id INTEGER DEFAULT 1,
             PRIMARY KEY (name, shop_id),

--- a/payments.py
+++ b/payments.py
@@ -470,6 +470,7 @@ def deliver_product(chat_id, username, first_name, name_good, amount, sum_amount
         if dop.is_manual_delivery(name_good):
             manual_msg = dop.get_manual_delivery_message(username, first_name)
             bot.send_message(chat_id, manual_msg)
+            dop.decrement_manual_stock(name_good, amount, shop_id)
         else:
             # Entregar producto físico/digital
             text = ''

--- a/tests/test_manual_stock.py
+++ b/tests/test_manual_stock.py
@@ -1,0 +1,38 @@
+import builtins, importlib, sys, types
+from pathlib import Path
+from tests.test_payments import setup_payments
+import sqlite3
+import files
+
+
+def test_manual_stock_decrements(monkeypatch, tmp_path):
+    monkeypatch.setattr(files, "main_db", str(tmp_path / "main.db"))
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE shops (id INTEGER PRIMARY KEY AUTOINCREMENT, admin_id INTEGER, name TEXT)")
+    cur.execute("CREATE TABLE goods (name TEXT, description TEXT, format TEXT, minimum INTEGER, price INTEGER, stored TEXT, shop_id INTEGER DEFAULT 1, PRIMARY KEY (name, shop_id))")
+    conn.commit()
+    conn.close()
+
+    payments, _ = setup_payments(monkeypatch, tmp_path)
+    dop = payments.dop
+    dop.ensure_database_schema()
+    dop.create_product(
+        "M1",
+        "desc",
+        "manual",
+        1,
+        2,
+        "x",
+        manual_delivery=1,
+        manual_stock=5,
+        shop_id=1,
+    )
+
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [])
+    monkeypatch.setattr(dop, "check_message", lambda *a, **k: False)
+    monkeypatch.setattr(dop, "get_manual_delivery_message", lambda u, n: "msg")
+
+    assert dop.amount_of_goods("M1", 1) == 5
+    payments.deliver_product(1, "u", "User", "M1", 2, 4, "PayPal")
+    assert dop.amount_of_goods("M1", 1) == 3


### PR DESCRIPTION
## Summary
- initialize `manual_stock` column for goods
- migrate existing DBs to add `manual_stock`
- support manual stock when creating and selling products
- prompt admin for stock level during manual product creation
- decrement manual stock when manual products are delivered
- test manual product stock decrement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f38f4c074833397822f8f2f005546