### PR TITLE
Support multimedia start message

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ En **💬 Respuestas** puedes definir distintos textos que el bot enviará. Se a
 **Agregar/Cambiar mensaje de entrega manual**, utilizado cuando un producto requiere
 entrega manual. En ese mensaje puedes incluir las palabras `username` y `name` para
 personalizarlo. Configurar **💬 Respuestas** es un privilegio exclusivo del super admin.
+Además, la bienvenida al usuario ahora admite multimedia. Al elegir *Añadir/Cambiar bienvenida al usuario* puedes
+subir una foto, video o documento opcional que se enviará junto al texto de bienvenida.
 
 ### Carga y edición de unidades
 

--- a/adminka.py
+++ b/adminka.py
@@ -145,10 +145,26 @@ def in_adminka(chat_id, message_text, username, name_user):
         elif ' bienvenida al usuario' in message_text or ' mensaje después de pagar el producto' in message_text or ' respuesta al comando help' in message_text or ' mensaje si no hay nombre de usuario' in message_text or 'mensaje de entrega manual' in message_text:
             key = telebot.types.InlineKeyboardMarkup()
             key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
-            if ' bienvenida al usuario' in message_text: 
+            if ' bienvenida al usuario' in message_text:
                 message = 'start'
-                bot.send_message(chat_id, '¡Ingrese un nuevo mensaje de bienvenida! En el texto puede usar las palabras `username` y `name`. Se reemplazarán automáticamente por el nombre de usuario', parse_mode='MarkDown', reply_markup=key)
-            elif ' mensaje después de pagar el producto' in message_text: 
+                media_key = telebot.types.InlineKeyboardMarkup()
+                media_key.add(
+                    telebot.types.InlineKeyboardButton(text='Omitir', callback_data='SKIP_START_MEDIA')
+                )
+                media_key.add(
+                    telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración')
+                )
+                bot.send_message(
+                    chat_id,
+                    'Envíe una foto, video o documento para la bienvenida (opcional) o presione "Omitir"',
+                    reply_markup=media_key
+                )
+                with open('data/Temp/' + str(chat_id) + '.txt', 'w', encoding='utf-8') as f:
+                    f.write(message)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 500
+                return
+            elif ' mensaje después de pagar el producto' in message_text:
                 message = 'after_buy'
                 bot.send_message(chat_id, '¡Ingrese un nuevo mensaje que el bot enviará al usuario después de la compra! En el texto puede usar las palabras `username` y `name`. Se reemplazarán automáticamente por el nombre de usuario', parse_mode='MarkDown', reply_markup=key)
             elif ' respuesta al comando help' in message_text: 
@@ -812,6 +828,11 @@ def text_analytics(message_text, chat_id):
                 return
             if message == 'manual_delivery':
                 success = dop.save_message('manual_delivery', message_text)
+            elif message == 'start':
+                media = dop.get_start_media()
+                fid = media['file_id'] if media else None
+                mtype = media['type'] if media else None
+                success = dop.save_message('start', message_text, file_id=fid, media_type=mtype)
             else:
                 try:
                     with shelve.open(files.bot_message_bd) as bd:
@@ -2180,6 +2201,25 @@ def ad_inline(callback_data, chat_id, message_id):
         with shelve.open(files.sost_bd) as bd:
             bd[str(chat_id)] = 2
 
+    elif callback_data == 'SKIP_START_MEDIA':
+        dop.remove_start_media()
+        key = telebot.types.InlineKeyboardMarkup()
+        key.add(
+            telebot.types.InlineKeyboardButton(
+                text='Cancelar y volver al menú principal de administración',
+                callback_data='Volver al menú principal de administración'
+            )
+        )
+        bot.edit_message_reply_markup(chat_id, message_id)
+        bot.send_message(
+            chat_id,
+            '¡Ingrese un nuevo mensaje de bienvenida! En el texto puede usar las palabras `username` y `name`. Se reemplazarán automáticamente por el nombre de usuario',
+            parse_mode='MarkDown',
+            reply_markup=key
+        )
+        with shelve.open(files.sost_bd) as bd:
+            bd[str(chat_id)] = 1
+
     elif callback_data == 'CONFIRM_BROADCAST':
         try:
             with open('data/Temp/' + str(chat_id) + '.txt', encoding='utf-8') as f:
@@ -2330,7 +2370,7 @@ def handle_multimedia(message):
         with shelve.open(files.sost_bd) as bd:
             state = bd.get(str(chat_id))
 
-        if state not in (32, 200, 42, 162, 165, 305):
+        if state not in (32, 200, 42, 162, 165, 305, 500):
             return
 
         if state == 32:
@@ -2343,6 +2383,8 @@ def handle_multimedia(message):
         elif state == 165:
             temp_path = None
         elif state == 305:
+            temp_path = None
+        elif state == 500:
             temp_path = None
         else:
             temp_path = 'data/Temp/' + str(chat_id) + 'new_media.txt'
@@ -2447,6 +2489,26 @@ def handle_multimedia(message):
                 with shelve.open(files.sost_bd) as bd:
                     del bd[str(chat_id)]
                 in_adminka(chat_id, '⚙️ Otros', None, None)
+                return
+            elif state == 500:
+                with shelve.open(files.bot_message_bd) as bd:
+                    bd['start_media_file_id'] = file_id
+                    bd['start_media_type'] = media_type
+                key = telebot.types.InlineKeyboardMarkup()
+                key.add(
+                    telebot.types.InlineKeyboardButton(
+                        text='Cancelar y volver al menú principal de administración',
+                        callback_data='Volver al menú principal de administración'
+                    )
+                )
+                bot.send_message(
+                    chat_id,
+                    '¡Ingrese un nuevo mensaje de bienvenida! En el texto puede usar las palabras `username` y `name`. Se reemplazarán automáticamente por el nombre de usuario',
+                    parse_mode='MarkDown',
+                    reply_markup=key
+                )
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 1
                 return
             else:
                 with open('data/Temp/' + str(chat_id) + 'new_media.txt', 'w', encoding='utf-8') as f:

--- a/dop.py
+++ b/dop.py
@@ -2005,14 +2005,47 @@ def format_product_with_media(product_name, shop_id=1):
         logging.error(f"Error formateando producto: {e}")
         return None
 
-def save_message(message_type, message_text):
+def save_message(message_type, message_text, file_id=None, media_type=None):
     """Guardar mensaje del bot"""
     try:
         with shelve.open(files.bot_message_bd) as bd:
             bd[message_type] = message_text
+            if message_type == 'start':
+                if file_id:
+                    bd['start_media_file_id'] = file_id
+                    bd['start_media_type'] = media_type
+                else:
+                    bd.pop('start_media_file_id', None)
+                    bd.pop('start_media_type', None)
         return True
     except Exception as e:
         logging.error(f"Error guardando mensaje: {e}")
+        return False
+
+
+def get_start_media():
+    """Obtener multimedia asociada al mensaje de inicio"""
+    try:
+        with shelve.open(files.bot_message_bd) as bd:
+            fid = bd.get('start_media_file_id')
+            mtype = bd.get('start_media_type')
+        if fid:
+            return {'file_id': fid, 'type': mtype}
+        return None
+    except Exception as e:
+        logging.error(f"Error obteniendo multimedia de inicio: {e}")
+        return None
+
+
+def remove_start_media():
+    """Eliminar multimedia del mensaje de inicio"""
+    try:
+        with shelve.open(files.bot_message_bd) as bd:
+            bd.pop('start_media_file_id', None)
+            bd.pop('start_media_type', None)
+        return True
+    except Exception as e:
+        logging.error(f"Error eliminando multimedia de inicio: {e}")
         return False
 
 

--- a/main.py
+++ b/main.py
@@ -73,7 +73,22 @@ def send_main_menu(chat_id, username, name):
             start_message = bd['start']
         start_message = start_message.replace('username', username or '')
         start_message = start_message.replace('name', name or '')
-        bot.send_message(chat_id, start_message, reply_markup=key)
+        media = dop.get_start_media()
+        if media:
+            if media['type'] == 'photo':
+                bot.send_photo(chat_id, media['file_id'], caption=start_message, reply_markup=key)
+            elif media['type'] == 'video':
+                bot.send_video(chat_id, media['file_id'], caption=start_message, reply_markup=key)
+            elif media['type'] == 'document':
+                bot.send_document(chat_id, media['file_id'], caption=start_message, reply_markup=key)
+            elif media['type'] == 'audio':
+                bot.send_audio(chat_id, media['file_id'], caption=start_message, reply_markup=key)
+            elif media['type'] == 'animation':
+                bot.send_animation(chat_id, media['file_id'], caption=start_message, reply_markup=key)
+            else:
+                bot.send_message(chat_id, start_message, reply_markup=key)
+        else:
+            bot.send_message(chat_id, start_message, reply_markup=key)
     else:
         bot.send_message(chat_id, '🏠 Inicio', reply_markup=key)
 
@@ -447,11 +462,27 @@ def inline(callback):
                         start_message = bd['start']
                     start_message = start_message.replace('username', callback.message.chat.username)
                     start_message = start_message.replace('name', callback.message.from_user.first_name)
-                    if callback.message.content_type != 'text':
+                    media = dop.get_start_media()
+                    if media:
                         bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                        bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
+                        if media['type'] == 'photo':
+                            bot.send_photo(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
+                        elif media['type'] == 'video':
+                            bot.send_video(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
+                        elif media['type'] == 'document':
+                            bot.send_document(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
+                        elif media['type'] == 'audio':
+                            bot.send_audio(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
+                        elif media['type'] == 'animation':
+                            bot.send_animation(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
+                        else:
+                            bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
                     else:
-                        dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
+                        if callback.message.content_type != 'text':
+                            bot.delete_message(callback.message.chat.id, callback.message.message_id)
+                            bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
+                        else:
+                            dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
 
         elif callback.data == 'Comprar':
             try:

--- a/tests/test_start_media.py
+++ b/tests/test_start_media.py
@@ -1,0 +1,28 @@
+from tests.test_categories import setup_dop
+from tests.test_shop_info import setup_main
+import os
+
+
+def test_start_media_helpers(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    os.makedirs('data/bd', exist_ok=True)
+
+    dop.save_message('start', 'hola', file_id='fid', media_type='photo')
+    assert dop.get_start_media() == {'file_id': 'fid', 'type': 'photo'}
+
+    dop.remove_start_media()
+    assert dop.get_start_media() is None
+
+
+def test_send_main_menu_uses_media(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    os.makedirs('data/bd', exist_ok=True)
+
+    dop.save_message('start', 'hola', file_id='fid', media_type='photo')
+
+    main.send_main_menu(5, 'u', 'N')
+    assert any(c[0] == 'send_photo' for c in calls)
+    assert any(c[2].get('caption') == 'hola' for c in calls if c[0] == 'send_photo')
+


### PR DESCRIPTION
## Summary
- allow storing media with start message
- show media when sending main menu
- enable admin to upload welcome media
- document how to add multimedia to the welcome message
- test helper and send_main_menu with media

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3f521ed08333b5eca7612f60b93b