### PR TITLE
Handle manual product stock

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -1327,39 +1327,57 @@ def text_analytics(message_text, chat_id):
                 return
 
             action = message_text.strip().lower()
-            file_path = f'data/goods/{shop_id}_{product}.txt'
-            if action == 'añadir unidades':
-                bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 180
-            elif action == 'editar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+            if dop.is_manual_delivery(product, shop_id):
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Indique cuántas unidades desea agregar:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 181
-            elif action == 'eliminar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+                        bd[str(chat_id)] = 183
+                elif action == 'editar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique la nueva cantidad total:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 182
+                        bd[str(chat_id)] = 184
+                elif action == 'eliminar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique cuántas unidades desea eliminar:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 185
+                else:
+                    show_product_menu(chat_id)
             else:
-                show_product_menu(chat_id)
+                file_path = f'data/goods/{shop_id}_{product}.txt'
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 180
+                elif action == 'editar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 181
+                elif action == 'eliminar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 182
+                else:
+                    show_product_menu(chat_id)
 
         elif sost_num == 180:
             try:
@@ -1434,6 +1452,66 @@ def text_analytics(message_text, chat_id):
             with open(file_path, 'w', encoding='utf-8') as f:
                 for line in new_lines:
                     f.write(line + '\n')
+            bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 183:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.add_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades añadidas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 184:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.set_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades editadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 185:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.decrement_manual_stock(product, qty, shop_id)
             bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]

--- a/dop.py
+++ b/dop.py
@@ -526,6 +526,43 @@ def decrement_manual_stock(name_good, quantity, shop_id=1):
         logging.error(f"Error decrementando manual_stock: {e}")
 
 
+def add_manual_stock(name_good, quantity, shop_id=1):
+    """Increase manual stock for a product."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "SELECT manual_stock FROM goods WHERE name = ? AND shop_id = ?",
+            (name_good, shop_id),
+        )
+        row = cursor.fetchone()
+        current = int(row[0]) if row and row[0] is not None else 0
+        new_val = current + int(quantity)
+        if new_val < 0:
+            new_val = 0
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (new_val, name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error incrementando manual_stock: {e}")
+
+
+def set_manual_stock(name_good, quantity, shop_id=1):
+    """Set manual stock to a specific value."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (int(quantity), name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error estableciendo manual_stock: {e}")
+
+
 def amount_of_goods(name_good, shop_id=1):
     if is_manual_delivery(name_good, shop_id):
         return get_manual_stock(name_good, shop_id)

--- a/tests/test_manual_stock.py
+++ b/tests/test_manual_stock.py
@@ -36,3 +36,27 @@ def test_manual_stock_decrements(monkeypatch, tmp_path):
     assert dop.amount_of_goods("M1", 1) == 5
     payments.deliver_product(1, "u", "User", "M1", 2, 4, "PayPal")
     assert dop.amount_of_goods("M1", 1) == 3
+
+
+def test_manual_stock_modifications(monkeypatch, tmp_path):
+    from tests.test_categories import setup_dop
+
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    dop.create_product(
+        "M2",
+        "desc",
+        "manual",
+        1,
+        1,
+        "x",
+        manual_delivery=1,
+        manual_stock=2,
+        shop_id=1,
+    )
+
+    assert dop.get_manual_stock("M2", 1) == 2
+    dop.add_manual_stock("M2", 3, 1)
+    assert dop.get_manual_stock("M2", 1) == 5
+    dop.set_manual_stock("M2", 10, 1)
+    assert dop.get_manual_stock("M2", 1) == 10


### PR DESCRIPTION
## Summary
- add helpers `add_manual_stock` and `set_manual_stock`
- extend admin product menu to manage manual stock with numeric input
- test manual stock modification behaviours

## Testing
- `python -m py_compile dop.py adminka.py tests/test_manual_stock.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25df480083338e372e246a636e45