### PR TITLE
Improve safe_edit_message logic

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -173,40 +173,61 @@ ensure_database_schema()
 # -------------------------------------------------
 def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
     """TRIPLE_FALLBACK - Edita mensajes de forma segura"""
+    first_try_caption = getattr(message, "content_type", "text") != "text"
+
     try:
-        bot.edit_message_text(
-            chat_id=message.chat.id,
-            message_id=message.message_id,
-            text=text,
-            reply_markup=reply_markup,
-            parse_mode=parse_mode
-        )
-        return True
-    except Exception as e:
-        logging.error(f"Error editando mensaje de texto: {e}")
-        try:
+        if first_try_caption:
             bot.edit_message_caption(
                 chat_id=message.chat.id,
                 message_id=message.message_id,
                 caption=text,
                 reply_markup=reply_markup,
-                parse_mode=parse_mode
+                parse_mode=parse_mode,
+            )
+        else:
+            bot.edit_message_text(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        return True
+    except Exception:
+        pass
+
+    try:
+        if first_try_caption:
+            bot.edit_message_text(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        else:
+            bot.edit_message_caption(
+                chat_id=message.chat.id,
+                message_id=message.message_id,
+                caption=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
+            )
+        return True
+    except Exception as e:
+        logging.error(f"Error editando mensaje: {e}")
+        try:
+            bot.delete_message(message.chat.id, message.message_id)
+            bot.send_message(
+                chat_id=message.chat.id,
+                text=text,
+                reply_markup=reply_markup,
+                parse_mode=parse_mode,
             )
             return True
         except Exception as e:
-            logging.error(f"Error editando caption del mensaje: {e}")
-            try:
-                bot.delete_message(message.chat.id, message.message_id)
-                bot.send_message(
-                    chat_id=message.chat.id,
-                    text=text,
-                    reply_markup=reply_markup,
-                    parse_mode=parse_mode
-                )
-                return True
-            except Exception as e:
-                logging.error(f"Error enviando nuevo mensaje: {e}")
-                return False
+            logging.error(f"Error enviando nuevo mensaje: {e}")
+            return False
 
 
 def it_first(chat_id):


### PR DESCRIPTION
## Summary
- check `message.content_type` in `safe_edit_message`
- attempt `edit_message_caption` first for non-text messages
- log a single error only when both edit operations fail

## Testing
- `python -m py_compile dop.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f52c8bc5c8333917d88bc1683b0b3