### PR TITLE
Improve discount settings UI and display

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -29,12 +29,23 @@ def show_discount_menu(chat_id):
 
     status = 'Activado ✅' if config_dis['enabled'] else 'Desactivado ❌'
     show_fake = 'Sí' if config_dis['show_fake_price'] else 'No'
+    fake_percent = dop.multiplier_to_percent(config_dis['multiplier'])
+    active = dop.get_active_discount_info(None, shop_id)
+    if active:
+        if active.get('end_time'):
+            rem = active['end_time'] - datetime.datetime.utcnow()
+            hrs = int(rem.total_seconds() // 3600)
+            active_msg = f"-{active['percent']}% ({hrs}h restantes)"
+        else:
+            active_msg = f"-{active['percent']}%"
+    else:
+        active_msg = 'Ninguno'
 
     user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
     toggle = 'Desactivar descuentos' if config_dis['enabled'] else 'Activar descuentos'
     toggle_fake = 'Ocultar precios tachados' if config_dis['show_fake_price'] else 'Mostrar precios tachados'
     user_markup.row(toggle)
-    user_markup.row('Cambiar texto', 'Cambiar multiplicador')
+    user_markup.row('Cambiar texto', 'Cambiar porcentaje')
     user_markup.row(toggle_fake)
     user_markup.row('Nuevo descuento')
     user_markup.row('Vista previa', 'Volver al menú principal')
@@ -43,8 +54,9 @@ def show_discount_menu(chat_id):
         f"💸 *Configuración de Descuentos*\n\n"
         f"Estado: {status}\n"
         f"Texto: {config_dis['text']}\n"
-        f"Multiplicador: x{config_dis['multiplier']}\n"
-        f"Mostrar precios tachados: {show_fake}"
+        f"Porcentaje ficticio: {fake_percent}%\n"
+        f"Mostrar precios tachados: {show_fake}\n"
+        f"Descuento activo: {active_msg}"
     )
 
     bot.send_message(chat_id, message, reply_markup=user_markup, parse_mode='Markdown')
@@ -509,6 +521,34 @@ def in_adminka(chat_id, message_text, username, name_user):
                 bd[str(chat_id)] = 60
 
         elif '💸 Descuentos' == message_text:
+            show_discount_menu(chat_id)
+
+        elif message_text in ('Desactivar descuentos', 'Activar descuentos'):
+            enable = message_text == 'Activar descuentos'
+            if dop.update_discount_config(enabled=enable, shop_id=shop_id):
+                status = 'activados' if enable else 'desactivados'
+                bot.send_message(chat_id, f'✅ Descuentos {status}')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando estado')
+            show_discount_menu(chat_id)
+
+        elif message_text == 'Cambiar texto':
+            bot.send_message(chat_id, 'Envíe el nuevo texto de descuento:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 33
+
+        elif message_text == 'Cambiar porcentaje':
+            bot.send_message(chat_id, 'Envíe el nuevo porcentaje (1-99):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 34
+
+        elif message_text in ('Ocultar precios tachados', 'Mostrar precios tachados'):
+            show = message_text == 'Mostrar precios tachados'
+            if dop.update_discount_config(show_fake_price=show, shop_id=shop_id):
+                msg = 'Mostrando precios tachados' if show else 'Ocultando precios tachados'
+                bot.send_message(chat_id, f'✅ {msg}')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando configuración')
             show_discount_menu(chat_id)
 
         elif 'Nuevo descuento' == message_text:
@@ -1327,39 +1367,57 @@ def text_analytics(message_text, chat_id):
                 return
 
             action = message_text.strip().lower()
-            file_path = f'data/goods/{shop_id}_{product}.txt'
-            if action == 'añadir unidades':
-                bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 180
-            elif action == 'editar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+            if dop.is_manual_delivery(product, shop_id):
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Indique cuántas unidades desea agregar:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 181
-            elif action == 'eliminar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+                        bd[str(chat_id)] = 183
+                elif action == 'editar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique la nueva cantidad total:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 182
+                        bd[str(chat_id)] = 184
+                elif action == 'eliminar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique cuántas unidades desea eliminar:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 185
+                else:
+                    show_product_menu(chat_id)
             else:
-                show_product_menu(chat_id)
+                file_path = f'data/goods/{shop_id}_{product}.txt'
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 180
+                elif action == 'editar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 181
+                elif action == 'eliminar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 182
+                else:
+                    show_product_menu(chat_id)
 
         elif sost_num == 180:
             try:
@@ -1434,6 +1492,66 @@ def text_analytics(message_text, chat_id):
             with open(file_path, 'w', encoding='utf-8') as f:
                 for line in new_lines:
                     f.write(line + '\n')
+            bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 183:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.add_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades añadidas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 184:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.set_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades editadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 185:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.decrement_manual_stock(product, qty, shop_id)
             bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
@@ -1836,16 +1954,19 @@ def text_analytics(message_text, chat_id):
 
 
 
-        elif sost_num == 34:  # Recibir nuevo multiplicador
+        elif sost_num == 34:  # Recibir nuevo porcentaje
             try:
-                multiplier = float(message_text)
+                percent = float(message_text)
+                if percent <= 0 or percent >= 100:
+                    raise ValueError
+                multiplier = dop.percent_to_multiplier(percent)
                 shop_id = dop.get_shop_id(chat_id)
                 if dop.update_discount_config(multiplier=multiplier, shop_id=shop_id):
-                    bot.send_message(chat_id, f'✅ Multiplicador actualizado a {multiplier}')
+                    bot.send_message(chat_id, f'✅ Porcentaje actualizado a {percent}%')
                 else:
-                    bot.send_message(chat_id, '❌ Error actualizando multiplicador')
+                    bot.send_message(chat_id, '❌ Error actualizando porcentaje')
             except ValueError:
-                bot.send_message(chat_id, '❌ Valor inválido, use punto decimal. Ej: 1.5')
+                bot.send_message(chat_id, '❌ Valor inválido, ingrese un número entre 1 y 99')
 
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]

--- a/dop.py
+++ b/dop.py
@@ -526,6 +526,43 @@ def decrement_manual_stock(name_good, quantity, shop_id=1):
         logging.error(f"Error decrementando manual_stock: {e}")
 
 
+def add_manual_stock(name_good, quantity, shop_id=1):
+    """Increase manual stock for a product."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "SELECT manual_stock FROM goods WHERE name = ? AND shop_id = ?",
+            (name_good, shop_id),
+        )
+        row = cursor.fetchone()
+        current = int(row[0]) if row and row[0] is not None else 0
+        new_val = current + int(quantity)
+        if new_val < 0:
+            new_val = 0
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (new_val, name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error incrementando manual_stock: {e}")
+
+
+def set_manual_stock(name_good, quantity, shop_id=1):
+    """Set manual stock to a specific value."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (int(quantity), name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error estableciendo manual_stock: {e}")
+
+
 def amount_of_goods(name_good, shop_id=1):
     if is_manual_delivery(name_good, shop_id):
         return get_manual_stock(name_good, shop_id)
@@ -1041,7 +1078,8 @@ def get_description(name_good, shop_id=1):
         product_description = f"*{name_good}*\n\n"
         product_description += f"📝 *Descripción:*\n{description}\n\n"
         
-        active_percent = get_active_discount(name_good, shop_id)
+        info = get_active_discount_info(name_good, shop_id)
+        active_percent = info['percent'] if info else 0
 
         if active_percent:
             new_price = int(price * (100 - active_percent) / 100)
@@ -1051,6 +1089,11 @@ def get_description(name_good, shop_id=1):
             product_description += "💰 *Precio:*\n"
             product_description += f"~~{crossed_price}~~\n"
             product_description += f"*${new_price} USD* (-{active_percent}% OFF)\n\n"
+            if info.get('end_time'):
+                remaining = info['end_time'] - datetime.datetime.utcnow()
+                hrs = int(remaining.total_seconds() // 3600)
+                if hrs > 0:
+                    product_description += f"⏳ *Tiempo restante:* {hrs}h\n"
         elif discount_config['enabled'] and discount_config['show_fake_price']:
             fake_price = int(price * discount_config['multiplier'])
             fake_price_str = str(fake_price) + ' USD'
@@ -1663,6 +1706,57 @@ def get_active_discount(product_or_cat_id, shop_id=1):
         logging.error(f"Error obteniendo descuento activo: {e}")
         return 0
 
+
+def get_active_discount_info(product_or_cat_id, shop_id=1):
+    """Devuelve información del descuento activo para un producto/categoría"""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+
+        if isinstance(product_or_cat_id, str):
+            cur.execute(
+                "SELECT category_id FROM goods WHERE name = ? AND shop_id = ?",
+                (product_or_cat_id, shop_id),
+            )
+            row = cur.fetchone()
+            category_id = row[0] if row else None
+        else:
+            category_id = product_or_cat_id
+
+        now = datetime.datetime.utcnow().isoformat()
+        cur.execute(
+            """
+            SELECT percent, end_time FROM discounts
+            WHERE shop_id = ? AND (category_id IS NULL OR category_id = ?)
+              AND start_time <= ? AND (end_time IS NULL OR end_time > ?)
+            ORDER BY percent DESC LIMIT 1
+            """,
+            (shop_id, category_id, now, now),
+        )
+        row = cur.fetchone()
+        if row:
+            percent = int(row[0])
+            end = row[1]
+            end_dt = datetime.datetime.fromisoformat(end) if end else None
+            return {"percent": percent, "end_time": end_dt}
+        return None
+    except Exception as e:
+        logging.error(f"Error obteniendo info de descuento activo: {e}")
+        return None
+
+
+def multiplier_to_percent(multiplier):
+    """Convierte un multiplicador en porcentaje de descuento falso."""
+    try:
+        return int(round((multiplier - 1) / multiplier * 100))
+    except Exception:
+        return 0
+
+
+def percent_to_multiplier(percent):
+    """Convierte un porcentaje en multiplicador para el precio tachado."""
+    return 100 / (100 - percent)
+
 # ============================================
 # FUNCIONES PARA DESCRIPCIÓN ADICIONAL
 # Agregadas automáticamente por el instalador
@@ -1970,9 +2064,10 @@ def format_product_with_media(product_name, shop_id=1):
             
         name, description, price, file_id, media_type, caption, duration, manual, category = result
 
-        discount = get_active_discount(name, shop_id)
-        display_price = price
         info = f"🎯 **{name}**\n"
+        d_info = get_active_discount_info(name, shop_id)
+        discount = d_info['percent'] if d_info else 0
+        display_price = price
         if discount:
             new_price = int(price * (100 - discount) / 100)
             display_price = new_price
@@ -1980,6 +2075,11 @@ def format_product_with_media(product_name, shop_id=1):
             array = list(orig_str)
             crossed = "̶" + "̶".join(array) + "̶"
             info += f"💰 **Precio:** ~~{crossed}~~ ${new_price} USD (-{discount}% OFF)\n"
+            if d_info.get('end_time'):
+                rem = d_info['end_time'] - datetime.datetime.utcnow()
+                hrs = int(rem.total_seconds() // 3600)
+                if hrs > 0:
+                    info += f"⏳ **Tiempo restante:** {hrs}h\n"
         else:
             info += f"💰 **Precio:** ${price} USD\n"
         info += f"📝 **Descripción:** {description}\n"

--- a/tests/test_discount_update.py
+++ b/tests/test_discount_update.py
@@ -1,0 +1,20 @@
+from tests.test_categories import setup_dop
+
+
+def test_toggle_discount_features(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conf = dop.get_discount_config()
+    assert conf['enabled']
+
+    dop.update_discount_config(enabled=False, shop_id=1)
+    assert not dop.get_discount_config()['enabled']
+
+    dop.update_discount_config(show_fake_price=False, shop_id=1)
+    assert not dop.get_discount_config()['show_fake_price']
+
+    dop.update_discount_config(text='X', multiplier=2.0, shop_id=1)
+    conf = dop.get_discount_config()
+    assert conf['text'] == 'X'
+    assert conf['multiplier'] == 2.0

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -17,10 +17,12 @@ def test_discount_creation_and_application(monkeypatch, tmp_path):
     conn.close()
 
     start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-    dop.create_discount(20, start, None, 1, 1)
+    end = datetime.datetime.utcnow() + datetime.timedelta(hours=5)
+    dop.create_discount(20, start, end, 1, 1)
 
     assert dop.get_active_discount('Prod', 1) == 20
     assert dop.order_sum('Prod', 2, 1) == 160
 
     desc = dop.get_description('Prod', 1)
     assert '80 USD' in desc
+    assert 'Tiempo restante' in desc

--- a/tests/test_manual_stock.py
+++ b/tests/test_manual_stock.py
@@ -36,3 +36,27 @@ def test_manual_stock_decrements(monkeypatch, tmp_path):
     assert dop.amount_of_goods("M1", 1) == 5
     payments.deliver_product(1, "u", "User", "M1", 2, 4, "PayPal")
     assert dop.amount_of_goods("M1", 1) == 3
+
+
+def test_manual_stock_modifications(monkeypatch, tmp_path):
+    from tests.test_categories import setup_dop
+
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    dop.create_product(
+        "M2",
+        "desc",
+        "manual",
+        1,
+        1,
+        "x",
+        manual_delivery=1,
+        manual_stock=2,
+        shop_id=1,
+    )
+
+    assert dop.get_manual_stock("M2", 1) == 2
+    dop.add_manual_stock("M2", 3, 1)
+    assert dop.get_manual_stock("M2", 1) == 5
+    dop.set_manual_stock("M2", 10, 1)
+    assert dop.get_manual_stock("M2", 1) == 10


### PR DESCRIPTION
## Summary
- rename admin option to `Cambiar porcentaje`
- compute fake discount percent from multiplier and show active discount info
- display remaining time for active discounts in product descriptions
- allow updating fake discount percent instead of multiplier
- test discount duration display

## Testing
- `python -m py_compile adminka.py dop.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25df480083338e372e246a636e45