### PR TITLE
Implement admin discount editing

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -34,7 +34,7 @@ def show_discount_menu(chat_id):
     toggle = 'Desactivar descuentos' if config_dis['enabled'] else 'Activar descuentos'
     toggle_fake = 'Ocultar precios tachados' if config_dis['show_fake_price'] else 'Mostrar precios tachados'
     user_markup.row(toggle)
-    user_markup.row('Cambiar texto', 'Cambiar multiplicador')
+    user_markup.row('Cambiar texto', 'Cambiar porcentaje')
     user_markup.row(toggle_fake)
     user_markup.row('Nuevo descuento')
     user_markup.row('Vista previa', 'Volver al menú principal')
@@ -525,8 +525,8 @@ def in_adminka(chat_id, message_text, username, name_user):
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 33
 
-        elif message_text == 'Cambiar multiplicador':
-            bot.send_message(chat_id, 'Envíe el nuevo multiplicador (ej. 1.5):')
+        elif message_text == 'Cambiar porcentaje':
+            bot.send_message(chat_id, 'Envíe el nuevo porcentaje de descuento:')
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 34
 
@@ -1942,16 +1942,16 @@ def text_analytics(message_text, chat_id):
 
 
 
-        elif sost_num == 34:  # Recibir nuevo multiplicador
+        elif sost_num == 34:  # Recibir nuevo porcentaje de descuento
             try:
-                multiplier = float(message_text)
+                percent = int(message_text)
                 shop_id = dop.get_shop_id(chat_id)
-                if dop.update_discount_config(multiplier=multiplier, shop_id=shop_id):
-                    bot.send_message(chat_id, f'✅ Multiplicador actualizado a {multiplier}')
+                if dop.update_active_discount_percent(percent, shop_id=shop_id):
+                    bot.send_message(chat_id, f'✅ Porcentaje actualizado a {percent}%')
                 else:
-                    bot.send_message(chat_id, '❌ Error actualizando multiplicador')
+                    bot.send_message(chat_id, '❌ Error actualizando porcentaje')
             except ValueError:
-                bot.send_message(chat_id, '❌ Valor inválido, use punto decimal. Ej: 1.5')
+                bot.send_message(chat_id, '❌ Porcentaje inválido. Use solo números enteros.')
 
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]

--- a/dop.py
+++ b/dop.py
@@ -1721,6 +1721,27 @@ def get_active_discount(product_or_cat_id, shop_id=1):
         logging.error(f"Error obteniendo descuento activo: {e}")
         return 0
 
+def update_active_discount_percent(new_percent, shop_id=1):
+    """Actualizar el porcentaje de cualquier descuento activo para la tienda"""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        now = datetime.datetime.utcnow().isoformat()
+        cur.execute(
+            """
+            UPDATE discounts
+            SET percent = ?
+            WHERE shop_id = ? AND start_time <= ?
+              AND (end_time IS NULL OR end_time > ?)
+            """,
+            (int(new_percent), shop_id, now, now),
+        )
+        con.commit()
+        return cur.rowcount > 0
+    except Exception as e:
+        logging.error(f"Error actualizando porcentaje de descuento: {e}")
+        return False
+
 # ============================================
 # FUNCIONES PARA DESCRIPCIÓN ADICIONAL
 # Agregadas automáticamente por el instalador

--- a/tests/test_discount_update.py
+++ b/tests/test_discount_update.py
@@ -1,3 +1,4 @@
+import sqlite3, datetime
 from tests.test_categories import setup_dop
 
 
@@ -18,3 +19,17 @@ def test_toggle_discount_features(monkeypatch, tmp_path):
     conf = dop.get_discount_config()
     assert conf['text'] == 'X'
     assert conf['multiplier'] == 2.0
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute("INSERT INTO goods (name, description, format, minimum, price, stored, shop_id) VALUES ('P','d','text',1,100,'x',1)")
+    conn.commit()
+    conn.close()
+
+    start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    dop.create_discount(10, start, None, None, 1)
+    assert dop.get_active_discount('P', 1) == 10
+
+    dop.update_active_discount_percent(25, shop_id=1)
+    assert dop.get_active_discount('P', 1) == 25
+


### PR DESCRIPTION
## Summary
- add helper to update active discount percent
- switch admin state 34 to update discount percent
- update discount menu and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f5aa034c08333801517cf46ba39ad