### PR TITLE
Fix error logging in adminka

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -11,6 +11,9 @@ from advertising_system.admin_integration import (
     get_admin_telegram_groups,
 )
 from bot_instance import bot
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 
 def session_expired(chat_id):
@@ -1825,7 +1828,7 @@ def text_analytics(message_text, chat_id):
             except FileNotFoundError:
                 session_expired(chat_id)
             except Exception as e:
-                print(f"Error en estado 29: {e}")
+                logging.error(f"Error en estado 29: {e}")
                 bot.send_message(chat_id, '❌ Error procesando la descripción adicional. Inténtelo de nuevo.')
 
         elif sost_num == 30:  # Seleccionar producto para agregar multimedia


### PR DESCRIPTION
## Summary
- import logging into `adminka.py`
- use `logging.error` instead of print for error message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f62d7718883339067aeb48d8fd2ec