### PR TITLE
Fix safe message edits

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -172,11 +172,10 @@ ensure_database_schema()
 # Utilidad para editar mensajes con o sin multimedia
 # -------------------------------------------------
 def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
-    """TRIPLE_FALLBACK - Edita mensajes de forma segura"""
-    content_type = getattr(message, "content_type", "text")
+    """Edita mensajes según su tipo y registra un error solo si ambos intentos fallan."""
 
     try:
-        if content_type == "text":
+        if getattr(message, "content_type", "text") == "text":
             bot.edit_message_text(
                 chat_id=message.chat.id,
                 message_id=message.message_id,
@@ -197,7 +196,7 @@ def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
         pass
 
     try:
-        if content_type == "text":
+        if getattr(message, "content_type", "text") == "text":
             bot.edit_message_caption(
                 chat_id=message.chat.id,
                 message_id=message.message_id,


### PR DESCRIPTION
## Summary
- refine `safe_edit_message` so that it checks `message.content_type` on each attempt
- only log an error if both edit attempts fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f63f91cd48333a422711d4f269489