### PR TITLE
Add shop rating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Desde allí puede crear nuevas tiendas y asignar el ID de Telegram de su adminis
 
 Cada administrador puede renombrar su tienda desde **⚙️ Otros** usando la opción *Cambiar nombre de tienda*.
 
+### Calificaciones de tienda
+
+Los clientes pueden puntuar a cada vendedor de 1 a 5 estrellas desde la portada de la tienda. La media de calificaciones aparece bajo la descripción y cada usuario puede actualizar su voto en cualquier momento eligiendo nuevamente el número de estrellas.
+
 Si vienes de una instalación antigua de una sola tienda, ejecuta `python migrate_add_shop_id.py` (o `init_db.py` si prefieres crear la base desde cero) para añadir la columna `shop_id` requerida.
 
 Para registrar la relación entre usuarios y tiendas existentes, ejecuta:

--- a/dop.py
+++ b/dop.py
@@ -135,6 +135,17 @@ def ensure_database_schema():
 
         cursor.execute(
             """
+            CREATE TABLE IF NOT EXISTS shop_ratings (
+                shop_id INTEGER,
+                user_id INTEGER,
+                rating INTEGER,
+                PRIMARY KEY (shop_id, user_id)
+            )
+            """
+        )
+
+        cursor.execute(
+            """
             CREATE TABLE IF NOT EXISTS discounts (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 percent INTEGER,
@@ -1073,6 +1084,39 @@ def get_user_shop(user_id):
     except Exception as e:
         logging.error(f"Error getting user shop: {e}")
         return 1
+
+def submit_shop_rating(shop_id, user_id, rating):
+    """Insertar o actualizar la calificación de un usuario para una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "INSERT OR REPLACE INTO shop_ratings (shop_id, user_id, rating) VALUES (?, ?, ?)",
+            (int(shop_id), int(user_id), int(rating)),
+        )
+        con.commit()
+        return True
+    except Exception as e:
+        logging.error(f"Error submitting shop rating: {e}")
+        return False
+
+def get_shop_rating(shop_id):
+    """Obtener promedio y cantidad de calificaciones de una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "SELECT AVG(rating), COUNT(*) FROM shop_ratings WHERE shop_id = ?",
+            (int(shop_id),),
+        )
+        row = cur.fetchone()
+        if row:
+            avg = float(row[0]) if row[0] is not None else 0.0
+            return avg, row[1]
+        return (0.0, 0)
+    except Exception as e:
+        logging.error(f"Error getting shop rating: {e}")
+        return (0.0, 0)
 
 def get_description(name_good, shop_id=1):
     """Descripción del producto con sistema de descuentos"""

--- a/init_db.py
+++ b/init_db.py
@@ -110,6 +110,16 @@ def create_database():
     ''')
     print("✓ Tabla 'shop_users' creada")
 
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS shop_ratings (
+            shop_id INTEGER,
+            user_id INTEGER,
+            rating INTEGER,
+            PRIMARY KEY (shop_id, user_id)
+        )
+    ''')
+    print("✓ Tabla 'shop_ratings' creada")
+
     # Tablas para sistema de publicidad
     cursor.execute('''
         CREATE TABLE IF NOT EXISTS campaigns (

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import telebot, shelve, sqlite3, os
+import telebot, shelve, sqlite3, os, types
 import config, dop, payments, adminka, files
 import db
 from bot_instance import bot
@@ -271,27 +271,32 @@ def inline(callback):
             shop_id = int(callback.data.replace('SELECT_SHOP_', ''))
             dop.set_user_shop(callback.message.chat.id, shop_id)
             info = dop.get_shop_info(shop_id)
+            avg, count = dop.get_shop_rating(shop_id)
+            desc = (info.get('description') or '') if info else ''
+            if count:
+                desc = f"{desc}\n⭐ {avg:.1f}/5 ({count})"
             if info and (info.get('description') or info.get('media_file_id')):
                 markup = telebot.types.InlineKeyboardMarkup()
                 if info.get('button1_text') and info.get('button1_url'):
                     markup.add(telebot.types.InlineKeyboardButton(text=info['button1_text'], url=info['button1_url']))
                 if info.get('button2_text') and info.get('button2_url'):
                     markup.add(telebot.types.InlineKeyboardButton(text=info['button2_text'], url=info['button2_url']))
+                markup.add(telebot.types.InlineKeyboardButton(text='⭐ Calificar vendedor', callback_data=f'RATE_SHOP_{shop_id}'))
                 if info.get('media_file_id'):
                     if info.get('media_type') == 'photo':
-                        bot.send_photo(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                        bot.send_photo(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
                     elif info.get('media_type') == 'video':
-                        bot.send_video(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                        bot.send_video(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
                     elif info.get('media_type') == 'document':
-                        bot.send_document(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                        bot.send_document(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
                     elif info.get('media_type') == 'audio':
-                        bot.send_audio(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                        bot.send_audio(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
                     elif info.get('media_type') == 'animation':
-                        bot.send_animation(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
+                        bot.send_animation(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
                     else:
-                        bot.send_message(callback.message.chat.id, info.get('description') or '', reply_markup=markup)
+                        bot.send_message(callback.message.chat.id, desc or '', reply_markup=markup)
                 else:
-                    bot.send_message(callback.message.chat.id, info.get('description'), reply_markup=markup)
+                    bot.send_message(callback.message.chat.id, desc, reply_markup=markup)
 
             categories = dop.list_categories(shop_id)
             key = telebot.types.InlineKeyboardMarkup()
@@ -307,6 +312,24 @@ def inline(callback):
             )
             if callback.message.content_type != 'text':
                 bot.delete_message(callback.message.chat.id, callback.message.message_id)
+
+        elif callback.data.startswith('RATE_SHOP_'):
+            shop_id = int(callback.data.replace('RATE_SHOP_', ''))
+            key = telebot.types.InlineKeyboardMarkup()
+            for i in range(1, 6):
+                key.add(telebot.types.InlineKeyboardButton(text='⭐' * i, callback_data=f'RATE_VAL_{shop_id}_{i}'))
+            bot.answer_callback_query(callback.id)
+            bot.send_message(callback.message.chat.id, 'Elige una calificación:', reply_markup=key)
+
+        elif callback.data.startswith('RATE_VAL_'):
+            parts = callback.data.split('_')
+            if len(parts) == 4:
+                shop_id = int(parts[2])
+                value = int(parts[3])
+                dop.submit_shop_rating(shop_id, callback.from_user.id, value)
+                bot.answer_callback_query(callback.id, text='¡Gracias por calificar!', show_alert=True)
+                cb = types.SimpleNamespace(data=f'SELECT_SHOP_{shop_id}', message=callback.message, id=callback.id, from_user=callback.from_user)
+                inline(cb)
 
         elif callback.data == 'Ir al catálogo de productos':
             # Optimización: usar conexión eficiente

--- a/tests/test_ratings.py
+++ b/tests/test_ratings.py
@@ -1,0 +1,20 @@
+import sqlite3
+from tests.test_categories import setup_dop
+
+
+def test_rating_average(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    dop.submit_shop_rating(1, 1, 5)
+    dop.submit_shop_rating(1, 2, 3)
+    avg, count = dop.get_shop_rating(1)
+
+    assert round(avg, 1) == 4.0
+    assert count == 2
+
+    # Reemplazar calificación del usuario 1
+    dop.submit_shop_rating(1, 1, 1)
+    avg, count = dop.get_shop_rating(1)
+    assert round(avg, 1) == 2.0
+    assert count == 2

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -153,3 +153,33 @@ def test_category_selection_lists_products(monkeypatch, tmp_path):
     btn_texts = [b.text for b in buttons]
     assert any("P1" in t for t in btn_texts)
     assert not any("P2" in t for t in btn_texts)
+
+
+def test_shop_rating_shown(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.update_shop_info(sid, description="desc")
+    dop.submit_shop_rating(sid, 1, 5)
+    dop.submit_shop_rating(sid, 2, 4)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5)
+            self.message_id = 1
+            self.content_type = "text"
+            self.from_user = types.SimpleNamespace(first_name="a")
+
+    cb = types.SimpleNamespace(data=f"SELECT_SHOP_{sid}", message=Msg(), id="1", from_user=types.SimpleNamespace(username="u"))
+    main.inline(cb)
+
+    first = next(c for c in calls if c[0] in ("send_message", "send_photo"))
+    if first[0] == "send_photo":
+        text = first[2]["caption"]
+        buttons = first[2]["reply_markup"].buttons
+    else:
+        text = first[1][1]
+        buttons = first[2]["reply_markup"].buttons
+
+    assert "4.5" in text
+    assert any(b.text.startswith("⭐") for b in buttons)


### PR DESCRIPTION
## Summary
- create `shop_ratings` table during initialization
- add helpers to submit and fetch shop ratings
- show average rating and rating button in shop view
- support rating actions via new callbacks
- document rating feature
- add unit tests for ratings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f69d3901883339a29c431f701c41f