### PR TITLE
Improve welcome message setup and shop info

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start
 
 Desde ese menú también podrás pulsar **"Mis compras"** para revisar un resumen de todos los productos que hayas adquirido.
 
+Si tienes problemas con un producto comprado puedes usar el comando `/report` (o `/reporte`) para enviar un reclamo al administrador. El bot te pedirá indicar el producto y una descripción del fallo.
+
 ## Múltiples tiendas
 
 El bot admite gestionar varias tiendas. El usuario cuyo ID figura en `TELEGRAM_ADMIN_ID` es el *super admin* y posee un menú adicional **🛍️ Gestionar tiendas** dentro de **⚙️ Otros**. Solo este super admin puede añadir o eliminar otros administradores.
@@ -110,8 +112,8 @@ En **💬 Respuestas** puedes definir distintos textos que el bot enviará. Se a
 **Agregar/Cambiar mensaje de entrega manual**, utilizado cuando un producto requiere
 entrega manual. En ese mensaje puedes incluir las palabras `username` y `name` para
 personalizarlo. Configurar **💬 Respuestas** es un privilegio exclusivo del super admin.
-Además, la bienvenida al usuario ahora admite multimedia. Al elegir *Añadir/Cambiar bienvenida al usuario* puedes
-subir una foto, video o documento opcional que se enviará junto al texto de bienvenida.
+Para modificar el mensaje mostrado al usar `/start`, selecciona **Configurar mensaje /start**.
+Podrás subir una foto, video o documento opcional que se enviará junto al texto de bienvenida.
 
 ### Carga y edición de unidades
 

--- a/adminka.py
+++ b/adminka.py
@@ -29,12 +29,23 @@ def show_discount_menu(chat_id):
 
     status = 'Activado ✅' if config_dis['enabled'] else 'Desactivado ❌'
     show_fake = 'Sí' if config_dis['show_fake_price'] else 'No'
+    fake_percent = dop.multiplier_to_percent(config_dis['multiplier'])
+    active = dop.get_active_discount_info(None, shop_id)
+    if active:
+        if active.get('end_time'):
+            rem = active['end_time'] - datetime.datetime.utcnow()
+            hrs = int(rem.total_seconds() // 3600)
+            active_msg = f"-{active['percent']}% ({hrs}h restantes)"
+        else:
+            active_msg = f"-{active['percent']}%"
+    else:
+        active_msg = 'Ninguno'
 
     user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
     toggle = 'Desactivar descuentos' if config_dis['enabled'] else 'Activar descuentos'
     toggle_fake = 'Ocultar precios tachados' if config_dis['show_fake_price'] else 'Mostrar precios tachados'
     user_markup.row(toggle)
-    user_markup.row('Cambiar texto', 'Cambiar multiplicador')
+    user_markup.row('Cambiar texto', 'Cambiar porcentaje')
     user_markup.row(toggle_fake)
     user_markup.row('Nuevo descuento')
     user_markup.row('Vista previa', 'Volver al menú principal')
@@ -43,8 +54,9 @@ def show_discount_menu(chat_id):
         f"💸 *Configuración de Descuentos*\n\n"
         f"Estado: {status}\n"
         f"Texto: {config_dis['text']}\n"
-        f"Multiplicador: x{config_dis['multiplier']}\n"
-        f"Mostrar precios tachados: {show_fake}"
+        f"Porcentaje ficticio: {fake_percent}%\n"
+        f"Mostrar precios tachados: {show_fake}\n"
+        f"Descuento activo: {active_msg}"
     )
 
     bot.send_message(chat_id, message, reply_markup=user_markup, parse_mode='Markdown')
@@ -118,10 +130,6 @@ def in_adminka(chat_id, message_text, username, name_user):
             if chat_id != config.admin_id:
                 bot.send_message(chat_id, '❌ Solo el super admin puede modificar las respuestas.')
                 return
-            if dop.check_message('start') is True:
-                start = 'Cambiar'
-            else: 
-                start = 'Añadir'
             if dop.check_message('after_buy'): 
                 after_buy = 'Cambiar'
             else: 
@@ -135,17 +143,17 @@ def in_adminka(chat_id, message_text, username, name_user):
             else: 
                 userfalse = 'Añadir'
             user_markup = telebot.types.ReplyKeyboardMarkup(True, True)
-            user_markup.row(start + ' bienvenida al usuario')
+            user_markup.row('Configurar mensaje /start')
             user_markup.row(after_buy + ' mensaje después de pagar el producto')
             user_markup.row(help + ' respuesta al comando help', userfalse + ' mensaje si no hay nombre de usuario')
             user_markup.row('Agregar/Cambiar mensaje de entrega manual')
             user_markup.row('Volver al menú principal')
             bot.send_message(chat_id, 'Seleccione qué mensaje desea cambiar.\nDespués de seleccionar, recibirá una breve instrucción', reply_markup=user_markup)
 
-        elif ' bienvenida al usuario' in message_text or ' mensaje después de pagar el producto' in message_text or ' respuesta al comando help' in message_text or ' mensaje si no hay nombre de usuario' in message_text or 'mensaje de entrega manual' in message_text:
+        elif message_text == 'Configurar mensaje /start' or ' mensaje después de pagar el producto' in message_text or ' respuesta al comando help' in message_text or ' mensaje si no hay nombre de usuario' in message_text or 'mensaje de entrega manual' in message_text:
             key = telebot.types.InlineKeyboardMarkup()
             key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver al menú principal de administración', callback_data='Volver al menú principal de administración'))
-            if ' bienvenida al usuario' in message_text:
+            if message_text == 'Configurar mensaje /start':
                 message = 'start'
                 media_key = telebot.types.InlineKeyboardMarkup()
                 media_key.add(
@@ -509,6 +517,34 @@ def in_adminka(chat_id, message_text, username, name_user):
                 bd[str(chat_id)] = 60
 
         elif '💸 Descuentos' == message_text:
+            show_discount_menu(chat_id)
+
+        elif message_text in ('Desactivar descuentos', 'Activar descuentos'):
+            enable = message_text == 'Activar descuentos'
+            if dop.update_discount_config(enabled=enable, shop_id=shop_id):
+                status = 'activados' if enable else 'desactivados'
+                bot.send_message(chat_id, f'✅ Descuentos {status}')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando estado')
+            show_discount_menu(chat_id)
+
+        elif message_text == 'Cambiar texto':
+            bot.send_message(chat_id, 'Envíe el nuevo texto de descuento:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 33
+
+        elif message_text == 'Cambiar porcentaje':
+            bot.send_message(chat_id, 'Envíe el nuevo porcentaje (1-99):')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 34
+
+        elif message_text in ('Ocultar precios tachados', 'Mostrar precios tachados'):
+            show = message_text == 'Mostrar precios tachados'
+            if dop.update_discount_config(show_fake_price=show, shop_id=shop_id):
+                msg = 'Mostrando precios tachados' if show else 'Ocultando precios tachados'
+                bot.send_message(chat_id, f'✅ {msg}')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando configuración')
             show_discount_menu(chat_id)
 
         elif 'Nuevo descuento' == message_text:
@@ -1327,39 +1363,57 @@ def text_analytics(message_text, chat_id):
                 return
 
             action = message_text.strip().lower()
-            file_path = f'data/goods/{shop_id}_{product}.txt'
-            if action == 'añadir unidades':
-                bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 180
-            elif action == 'editar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+            if dop.is_manual_delivery(product, shop_id):
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Indique cuántas unidades desea agregar:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 181
-            elif action == 'eliminar unidades':
-                if not os.path.exists(file_path):
-                    bot.send_message(chat_id, 'El producto aún no tiene unidades.')
-                    show_product_menu(chat_id)
+                        bd[str(chat_id)] = 183
+                elif action == 'editar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique la nueva cantidad total:')
                     with shelve.open(files.sost_bd) as bd:
-                        del bd[str(chat_id)]
-                    return
-                with open(file_path, 'r', encoding='utf-8') as f:
-                    lines = [ln.rstrip('\n') for ln in f.readlines()]
-                text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
-                with shelve.open(files.sost_bd) as bd:
-                    bd[str(chat_id)] = 182
+                        bd[str(chat_id)] = 184
+                elif action == 'eliminar unidades':
+                    current = dop.get_manual_stock(product, shop_id)
+                    bot.send_message(chat_id, f'Stock actual: {current}\nIndique cuántas unidades desea eliminar:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 185
+                else:
+                    show_product_menu(chat_id)
             else:
-                show_product_menu(chat_id)
+                file_path = f'data/goods/{shop_id}_{product}.txt'
+                if action == 'añadir unidades':
+                    bot.send_message(chat_id, 'Envíe las unidades a añadir, una por línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 180
+                elif action == 'editar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 181
+                elif action == 'eliminar unidades':
+                    if not os.path.exists(file_path):
+                        bot.send_message(chat_id, 'El producto aún no tiene unidades.')
+                        show_product_menu(chat_id)
+                        with shelve.open(files.sost_bd) as bd:
+                            del bd[str(chat_id)]
+                        return
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        lines = [ln.rstrip('\n') for ln in f.readlines()]
+                    text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
+                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
+                    with shelve.open(files.sost_bd) as bd:
+                        bd[str(chat_id)] = 182
+                else:
+                    show_product_menu(chat_id)
 
         elif sost_num == 180:
             try:
@@ -1434,6 +1488,66 @@ def text_analytics(message_text, chat_id):
             with open(file_path, 'w', encoding='utf-8') as f:
                 for line in new_lines:
                     f.write(line + '\n')
+            bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 183:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.add_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades añadidas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 184:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.set_manual_stock(product, qty, shop_id)
+            bot.send_message(chat_id, '¡Unidades editadas con éxito!')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            show_product_menu(chat_id)
+
+        elif sost_num == 185:
+            try:
+                with open('data/Temp/' + str(chat_id) + '_product.txt', encoding='utf-8') as f:
+                    product = f.read()
+            except FileNotFoundError:
+                session_expired(chat_id)
+                return
+            try:
+                qty = int(message_text)
+                if qty < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, 'Cantidad inválida.')
+                return
+            dop.decrement_manual_stock(product, qty, shop_id)
             bot.send_message(chat_id, '¡Unidades eliminadas con éxito!')
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
@@ -1836,16 +1950,19 @@ def text_analytics(message_text, chat_id):
 
 
 
-        elif sost_num == 34:  # Recibir nuevo multiplicador
+        elif sost_num == 34:  # Recibir nuevo porcentaje
             try:
-                multiplier = float(message_text)
+                percent = float(message_text)
+                if percent <= 0 or percent >= 100:
+                    raise ValueError
+                multiplier = dop.percent_to_multiplier(percent)
                 shop_id = dop.get_shop_id(chat_id)
                 if dop.update_discount_config(multiplier=multiplier, shop_id=shop_id):
-                    bot.send_message(chat_id, f'✅ Multiplicador actualizado a {multiplier}')
+                    bot.send_message(chat_id, f'✅ Porcentaje actualizado a {percent}%')
                 else:
-                    bot.send_message(chat_id, '❌ Error actualizando multiplicador')
+                    bot.send_message(chat_id, '❌ Error actualizando porcentaje')
             except ValueError:
-                bot.send_message(chat_id, '❌ Valor inválido, use punto decimal. Ej: 1.5')
+                bot.send_message(chat_id, '❌ Valor inválido, ingrese un número entre 1 y 99')
 
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]

--- a/dop.py
+++ b/dop.py
@@ -160,6 +160,21 @@ def ensure_database_schema():
             """
         )
 
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS product_reports (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER,
+                username TEXT,
+                product_name TEXT,
+                description TEXT,
+                timestamp TEXT,
+                status TEXT DEFAULT 'open',
+                shop_id INTEGER DEFAULT 1
+            )
+            """
+        )
+
 
         if updated:
             con.commit()
@@ -524,6 +539,43 @@ def decrement_manual_stock(name_good, quantity, shop_id=1):
         con.commit()
     except Exception as e:
         logging.error(f"Error decrementando manual_stock: {e}")
+
+
+def add_manual_stock(name_good, quantity, shop_id=1):
+    """Increase manual stock for a product."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "SELECT manual_stock FROM goods WHERE name = ? AND shop_id = ?",
+            (name_good, shop_id),
+        )
+        row = cursor.fetchone()
+        current = int(row[0]) if row and row[0] is not None else 0
+        new_val = current + int(quantity)
+        if new_val < 0:
+            new_val = 0
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (new_val, name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error incrementando manual_stock: {e}")
+
+
+def set_manual_stock(name_good, quantity, shop_id=1):
+    """Set manual stock to a specific value."""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            "UPDATE goods SET manual_stock = ? WHERE name = ? AND shop_id = ?",
+            (int(quantity), name_good, shop_id),
+        )
+        con.commit()
+    except Exception as e:
+        logging.error(f"Error estableciendo manual_stock: {e}")
 
 
 def amount_of_goods(name_good, shop_id=1):
@@ -1041,7 +1093,8 @@ def get_description(name_good, shop_id=1):
         product_description = f"*{name_good}*\n\n"
         product_description += f"📝 *Descripción:*\n{description}\n\n"
         
-        active_percent = get_active_discount(name_good, shop_id)
+        info = get_active_discount_info(name_good, shop_id)
+        active_percent = info['percent'] if info else 0
 
         if active_percent:
             new_price = int(price * (100 - active_percent) / 100)
@@ -1051,6 +1104,11 @@ def get_description(name_good, shop_id=1):
             product_description += "💰 *Precio:*\n"
             product_description += f"~~{crossed_price}~~\n"
             product_description += f"*${new_price} USD* (-{active_percent}% OFF)\n\n"
+            if info.get('end_time'):
+                remaining = info['end_time'] - datetime.datetime.utcnow()
+                hrs = int(remaining.total_seconds() // 3600)
+                if hrs > 0:
+                    product_description += f"⏳ *Tiempo restante:* {hrs}h\n"
         elif discount_config['enabled'] and discount_config['show_fake_price']:
             fake_price = int(price * discount_config['multiplier'])
             fake_price_str = str(fake_price) + ' USD'
@@ -1323,6 +1381,45 @@ def new_buy_improved(his_id, username, name_good, amount, price, payment_method=
     except Exception as e:
         logging.error(f"Error en new_buy_improved: {e}")
         return False
+
+def create_product_report(user_id, username, product_name, description, shop_id=1):
+    """Guardar un reporte de problema enviado por un cliente"""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        now = datetime.datetime.utcnow().isoformat()
+        cursor.execute(
+            """
+            INSERT INTO product_reports
+            (user_id, username, product_name, description, timestamp, shop_id)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (user_id, username, product_name, description, now, shop_id),
+        )
+        con.commit()
+        return True
+    except Exception as e:
+        logging.error(f"Error creando reporte: {e}")
+        return False
+
+def list_product_reports(shop_id=1, status="open"):
+    """Obtener reportes registrados para una tienda"""
+    try:
+        con = db.get_db_connection()
+        cursor = con.cursor()
+        cursor.execute(
+            """
+            SELECT id, user_id, username, product_name, description, timestamp, status
+            FROM product_reports
+            WHERE shop_id = ? AND status = ?
+            ORDER BY timestamp DESC
+            """,
+            (shop_id, status),
+        )
+        return cursor.fetchall()
+    except Exception as e:
+        logging.error(f"Error listando reportes: {e}")
+        return []
 
 def get_daily_sales(shop_id=1):
     """Obtiene las ventas del día actual"""
@@ -1663,6 +1760,57 @@ def get_active_discount(product_or_cat_id, shop_id=1):
         logging.error(f"Error obteniendo descuento activo: {e}")
         return 0
 
+
+def get_active_discount_info(product_or_cat_id, shop_id=1):
+    """Devuelve información del descuento activo para un producto/categoría"""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+
+        if isinstance(product_or_cat_id, str):
+            cur.execute(
+                "SELECT category_id FROM goods WHERE name = ? AND shop_id = ?",
+                (product_or_cat_id, shop_id),
+            )
+            row = cur.fetchone()
+            category_id = row[0] if row else None
+        else:
+            category_id = product_or_cat_id
+
+        now = datetime.datetime.utcnow().isoformat()
+        cur.execute(
+            """
+            SELECT percent, end_time FROM discounts
+            WHERE shop_id = ? AND (category_id IS NULL OR category_id = ?)
+              AND start_time <= ? AND (end_time IS NULL OR end_time > ?)
+            ORDER BY percent DESC LIMIT 1
+            """,
+            (shop_id, category_id, now, now),
+        )
+        row = cur.fetchone()
+        if row:
+            percent = int(row[0])
+            end = row[1]
+            end_dt = datetime.datetime.fromisoformat(end) if end else None
+            return {"percent": percent, "end_time": end_dt}
+        return None
+    except Exception as e:
+        logging.error(f"Error obteniendo info de descuento activo: {e}")
+        return None
+
+
+def multiplier_to_percent(multiplier):
+    """Convierte un multiplicador en porcentaje de descuento falso."""
+    try:
+        return int(round((multiplier - 1) / multiplier * 100))
+    except Exception:
+        return 0
+
+
+def percent_to_multiplier(percent):
+    """Convierte un porcentaje en multiplicador para el precio tachado."""
+    return 100 / (100 - percent)
+
 # ============================================
 # FUNCIONES PARA DESCRIPCIÓN ADICIONAL
 # Agregadas automáticamente por el instalador
@@ -1970,9 +2118,10 @@ def format_product_with_media(product_name, shop_id=1):
             
         name, description, price, file_id, media_type, caption, duration, manual, category = result
 
-        discount = get_active_discount(name, shop_id)
-        display_price = price
         info = f"🎯 **{name}**\n"
+        d_info = get_active_discount_info(name, shop_id)
+        discount = d_info['percent'] if d_info else 0
+        display_price = price
         if discount:
             new_price = int(price * (100 - discount) / 100)
             display_price = new_price
@@ -1980,6 +2129,11 @@ def format_product_with_media(product_name, shop_id=1):
             array = list(orig_str)
             crossed = "̶" + "̶".join(array) + "̶"
             info += f"💰 **Precio:** ~~{crossed}~~ ${new_price} USD (-{discount}% OFF)\n"
+            if d_info.get('end_time'):
+                rem = d_info['end_time'] - datetime.datetime.utcnow()
+                hrs = int(rem.total_seconds() // 3600)
+                if hrs > 0:
+                    info += f"⏳ **Tiempo restante:** {hrs}h\n"
         else:
             info += f"💰 **Precio:** ${price} USD\n"
         info += f"📝 **Descripción:** {description}\n"

--- a/init_db.py
+++ b/init_db.py
@@ -276,6 +276,21 @@ def create_database():
         )
     ''')
     print("✓ Tabla 'discount_config' creada")
+
+    # Tabla para reportes de productos
+    cursor.execute('''
+        CREATE TABLE IF NOT EXISTS product_reports (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            username TEXT,
+            product_name TEXT,
+            description TEXT,
+            timestamp TEXT,
+            status TEXT DEFAULT 'open',
+            shop_id INTEGER DEFAULT 1
+        )
+    ''')
+    print("✓ Tabla 'product_reports' creada")
     
     conn.commit()
     conn.close()

--- a/main.py
+++ b/main.py
@@ -168,6 +168,13 @@ def message_send(message):
             in_admin.append(message.chat.id)
         adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
 
+    elif message.text.lower() in ('/report', '/reporte'):
+        key = telebot.types.InlineKeyboardMarkup()
+        key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='cancel_report'))
+        bot.send_message(message.chat.id, '📦 ¿Qué producto presenta fallas?', reply_markup=key)
+        with shelve.open(files.sost_bd) as bd:
+            bd[str(message.chat.id)] = 23
+
     elif dop.get_sost(message.chat.id) is True:
         if message.chat.id in in_admin:
             adminka.text_analytics(message.text, message.chat.id)
@@ -223,6 +230,36 @@ def message_send(message):
                     bot.send_message(message.chat.id,
                                      '❌ **¡La cantidad debe ser un número válido!**\n\n🔢 Envía solo números (ej: 5)',
                                      parse_mode='Markdown', reply_markup=key)
+            elif sost_num == 23:
+                with open(f'data/Temp/{message.chat.id}_report_prod.txt', 'w', encoding='utf-8') as f:
+                    f.write(message.text.strip())
+                bot.send_message(message.chat.id, '📝 Describe el problema con el producto:')
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(message.chat.id)] = 24
+            elif sost_num == 24:
+                try:
+                    with open(f'data/Temp/{message.chat.id}_report_prod.txt', encoding='utf-8') as f:
+                        prod = f.read().strip()
+                except FileNotFoundError:
+                    session_expired(message.chat.id, message.chat.username, message.from_user.first_name)
+                    return
+                desc = message.text
+                shop_id = dop.get_user_shop(message.chat.id)
+                dop.create_product_report(message.chat.id, message.chat.username, prod, desc, shop_id)
+                for admin_id in dop.get_adminlist():
+                    try:
+                        bot.send_message(admin_id,
+                                         f'🆘 *Nuevo reporte*\nUsuario: {message.chat.id} (@{message.chat.username or "sin username"})\nProducto: {prod}\nDescripción: {desc}',
+                                         parse_mode='Markdown')
+                    except Exception:
+                        pass
+                bot.send_message(message.chat.id, '✅ Tu reporte fue enviado al administrador.')
+                try:
+                    os.remove(f'data/Temp/{message.chat.id}_report_prod.txt')
+                except Exception:
+                    pass
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(message.chat.id)]
 
     elif message.chat.id in in_admin:
         adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
@@ -260,8 +297,21 @@ def inline(callback):
         
         # Manejar envío de comprobantes
         elif callback.data == 'Enviar comprobante Binance':
-            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True, 
+            bot.answer_callback_query(callback_query_id=callback.id, show_alert=True,
                                      text='📱 Envía una captura de pantalla del comprobante de pago como imagen al chat')
+            return
+
+        elif callback.data == 'cancel_report':
+            if dop.get_sost(callback.message.chat.id):
+                with shelve.open(files.sost_bd) as bd:
+                    if str(callback.message.chat.id) in bd:
+                        del bd[str(callback.message.chat.id)]
+            try:
+                os.remove(f'data/Temp/{callback.message.chat.id}_report_prod.txt')
+            except Exception:
+                pass
+            bot.answer_callback_query(callback.id, show_alert=True, text='Reporte cancelado')
+            send_main_menu(callback.message.chat.id, callback.from_user.username, callback.from_user.first_name)
             return
         
         if callback.message.chat.id in in_admin:
@@ -271,43 +321,35 @@ def inline(callback):
             shop_id = int(callback.data.replace('SELECT_SHOP_', ''))
             dop.set_user_shop(callback.message.chat.id, shop_id)
             info = dop.get_shop_info(shop_id)
-            if info and (info.get('description') or info.get('media_file_id')):
-                markup = telebot.types.InlineKeyboardMarkup()
+            markup = telebot.types.InlineKeyboardMarkup()
+            if info:
                 if info.get('button1_text') and info.get('button1_url'):
                     markup.add(telebot.types.InlineKeyboardButton(text=info['button1_text'], url=info['button1_url']))
                 if info.get('button2_text') and info.get('button2_url'):
                     markup.add(telebot.types.InlineKeyboardButton(text=info['button2_text'], url=info['button2_url']))
-                if info.get('media_file_id'):
-                    if info.get('media_type') == 'photo':
-                        bot.send_photo(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
-                    elif info.get('media_type') == 'video':
-                        bot.send_video(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
-                    elif info.get('media_type') == 'document':
-                        bot.send_document(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
-                    elif info.get('media_type') == 'audio':
-                        bot.send_audio(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
-                    elif info.get('media_type') == 'animation':
-                        bot.send_animation(callback.message.chat.id, info['media_file_id'], caption=info.get('description') or '', reply_markup=markup)
-                    else:
-                        bot.send_message(callback.message.chat.id, info.get('description') or '', reply_markup=markup)
-                else:
-                    bot.send_message(callback.message.chat.id, info.get('description'), reply_markup=markup)
+            markup.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
+            markup.add(telebot.types.InlineKeyboardButton(text='📜 Mis compras', callback_data='Ver mis compras'))
 
-            categories = dop.list_categories(shop_id)
-            key = telebot.types.InlineKeyboardMarkup()
-            for cid, cname in categories:
-                key.add(telebot.types.InlineKeyboardButton(text=cname, callback_data=f'CAT_{cid}'))
-            key.add(telebot.types.InlineKeyboardButton(text='Todos los productos', callback_data='CAT_NONE'))
-            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
-            bot.send_message(
-                callback.message.chat.id,
-                '📂 **SELECCIONA UNA CATEGORÍA**',
-                reply_markup=key,
-                parse_mode='Markdown'
-            )
+            desc = info.get('description') if info else ''
+            if info and info.get('media_file_id'):
+                mtype = info.get('media_type')
+                if mtype == 'photo':
+                    bot.send_photo(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
+                elif mtype == 'video':
+                    bot.send_video(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
+                elif mtype == 'document':
+                    bot.send_document(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
+                elif mtype == 'audio':
+                    bot.send_audio(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
+                elif mtype == 'animation':
+                    bot.send_animation(callback.message.chat.id, info['media_file_id'], caption=desc, reply_markup=markup)
+                else:
+                    bot.send_message(callback.message.chat.id, desc, reply_markup=markup)
+            else:
+                bot.send_message(callback.message.chat.id, desc or 'Tienda seleccionada', reply_markup=markup)
             if callback.message.content_type != 'text':
                 bot.delete_message(callback.message.chat.id, callback.message.message_id)
-
+            
         elif callback.data == 'Ir al catálogo de productos':
             # Optimización: usar conexión eficiente
             con = dop.get_db_connection() if hasattr(dop, 'get_db_connection') else db.get_db_connection()

--- a/tests/test_discount_update.py
+++ b/tests/test_discount_update.py
@@ -1,0 +1,20 @@
+from tests.test_categories import setup_dop
+
+
+def test_toggle_discount_features(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conf = dop.get_discount_config()
+    assert conf['enabled']
+
+    dop.update_discount_config(enabled=False, shop_id=1)
+    assert not dop.get_discount_config()['enabled']
+
+    dop.update_discount_config(show_fake_price=False, shop_id=1)
+    assert not dop.get_discount_config()['show_fake_price']
+
+    dop.update_discount_config(text='X', multiplier=2.0, shop_id=1)
+    conf = dop.get_discount_config()
+    assert conf['text'] == 'X'
+    assert conf['multiplier'] == 2.0

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -17,10 +17,12 @@ def test_discount_creation_and_application(monkeypatch, tmp_path):
     conn.close()
 
     start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-    dop.create_discount(20, start, None, 1, 1)
+    end = datetime.datetime.utcnow() + datetime.timedelta(hours=5)
+    dop.create_discount(20, start, end, 1, 1)
 
     assert dop.get_active_discount('Prod', 1) == 20
     assert dop.order_sum('Prod', 2, 1) == 160
 
     desc = dop.get_description('Prod', 1)
     assert '80 USD' in desc
+    assert 'Tiempo restante' in desc

--- a/tests/test_manual_stock.py
+++ b/tests/test_manual_stock.py
@@ -36,3 +36,27 @@ def test_manual_stock_decrements(monkeypatch, tmp_path):
     assert dop.amount_of_goods("M1", 1) == 5
     payments.deliver_product(1, "u", "User", "M1", 2, 4, "PayPal")
     assert dop.amount_of_goods("M1", 1) == 3
+
+
+def test_manual_stock_modifications(monkeypatch, tmp_path):
+    from tests.test_categories import setup_dop
+
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    dop.create_product(
+        "M2",
+        "desc",
+        "manual",
+        1,
+        1,
+        "x",
+        manual_delivery=1,
+        manual_stock=2,
+        shop_id=1,
+    )
+
+    assert dop.get_manual_stock("M2", 1) == 2
+    dop.add_manual_stock("M2", 3, 1)
+    assert dop.get_manual_stock("M2", 1) == 5
+    dop.set_manual_stock("M2", 10, 1)
+    assert dop.get_manual_stock("M2", 1) == 10

--- a/tests/test_product_reports.py
+++ b/tests/test_product_reports.py
@@ -1,0 +1,16 @@
+from tests.test_categories import setup_dop
+import sqlite3
+
+
+def test_create_product_report(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    assert dop.create_product_report(1, 'user', 'P1', 'bad', 1)
+
+    conn = sqlite3.connect(tmp_path / 'main.db')
+    cur = conn.cursor()
+    cur.execute("SELECT product_name, description FROM product_reports")
+    row = cur.fetchone()
+    conn.close()
+    assert row == ('P1', 'bad')

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -114,8 +114,14 @@ def test_shop_selection_shows_info(monkeypatch, tmp_path):
             self.from_user = types.SimpleNamespace(first_name="a")
     cb = types.SimpleNamespace(data=f"SELECT_SHOP_{sid}", message=Msg(), id="1", from_user=types.SimpleNamespace(username="u"))
     main.inline(cb)
-    assert any(c[0] == "send_photo" for c in calls)
-    assert any("CATEGORÍA" in c[1][1] for c in calls if c[0] == "send_message")
+    photo_calls = [c for c in calls if c[0] == "send_photo"]
+    assert photo_calls
+    buttons = photo_calls[0][2]["reply_markup"].buttons
+    texts = [b.text for b in buttons]
+    assert "B1" in texts
+    assert "🛍️ Catálogo" in texts
+    assert "📜 Mis compras" in texts
+    assert not any("CATEGORÍA" in c[1][1] for c in calls if c[0] == "send_message")
 
 
 def test_category_selection_lists_products(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- allow configuring `/start` text via **Configurar mensaje /start**
- remove old admin menu option
- send shop description and buttons in one message when selecting a shop
- update documentation and tests
- add product issue reporting for clients via `/report`

## Testing
- `python -m py_compile adminka.py main.py dop.py payments.py init_db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f25df480083338e372e246a636e45