### PR TITLE
Add /report command parsing and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,11 @@ import telebot, shelve, sqlite3, os, types
 import config, dop, payments, adminka, files
 import db
 from bot_instance import bot
+
+try:
+    bot_username = bot.get_me().username.lower()
+except Exception:
+    bot_username = ''
 from advertising_system.admin_integration import add_bot_group, remove_bot_group
 import atexit
 import glob
@@ -167,6 +172,15 @@ def message_send(message):
         if message.chat.id not in in_admin:
             in_admin.append(message.chat.id)
         adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
+
+    elif isinstance(message.text, str):
+        cmd = message.text.split()[0].lower()
+        if cmd in ('/report', '/reporte', f'/report@{bot_username}', f'/reporte@{bot_username}'):
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            bot.send_message(message.chat.id, '📝 Por favor escribe tu reporte:', reply_markup=key)
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(message.chat.id)] = 23
 
     elif dop.get_sost(message.chat.id) is True:
         if message.chat.id in in_admin:

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -1,0 +1,22 @@
+from tests.test_shop_info import setup_main
+import shelve, types, os
+
+
+def test_report_command_sets_state(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    os.makedirs('data/bd', exist_ok=True)
+    monkeypatch.setattr(main.files, 'sost_bd', str(tmp_path / 'sost.bd'))
+    monkeypatch.setattr(main.bot, 'get_me', lambda: types.SimpleNamespace(username='mybot'), raising=False)
+    main.bot_username = main.bot.get_me().username.lower()
+
+    class Msg:
+        def __init__(self, text):
+            self.text = text
+            self.chat = types.SimpleNamespace(id=5, username='u')
+            self.from_user = types.SimpleNamespace(first_name='N')
+    msg = Msg('/report@mybot')
+    main.message_send(msg)
+    with shelve.open(main.files.sost_bd) as bd:
+        assert bd[str(msg.chat.id)] == 23
+    assert any(c[0] == 'send_message' for c in calls)


### PR DESCRIPTION
## Summary
- fetch bot username at startup if available
- handle `/report` and `/reporte` including username mentions
- test `/report@mybot` sets user state 23

## Testing
- `pytest tests/test_report_command.py::test_report_command_sets_state -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f76fe6fc883339c45a1479463c3e9