### PR TITLE
Validate admin access before entering /adm

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,9 +169,18 @@ def message_send(message):
             dop.user_loger(chat_id=message.chat.id)
 			
     elif '/adm' == message.text:
-        if message.chat.id not in in_admin:
-            in_admin.append(message.chat.id)
-        adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
+        admin_list = dop.get_adminlist()
+        # Limpiar IDs que ya no son administradores
+        for uid in list(in_admin):
+            if uid not in admin_list:
+                in_admin.remove(uid)
+
+        if message.chat.id in admin_list:
+            if message.chat.id not in in_admin:
+                in_admin.append(message.chat.id)
+            adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
+        else:
+            bot.send_message(message.chat.id, '❌ No tienes permisos de administrador')
 
     elif isinstance(message.text, str):
         cmd = message.text.split()[0].lower()


### PR DESCRIPTION
## Summary
- add check that `/adm` command user is in `dop.get_adminlist()`
- clean `in_admin` from unauthorized ids
- notify unauthorized users they lack admin rights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687008979f1c833391182779a3ba2c0f