### PR TITLE
Add admin connection verification tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ Para ejecutar las pruebas automatizadas instala las dependencias y luego ejecuta
 pytest
 ```
 
+## Depuración
+
+Para verificar que la conexión con el administrador funcione correctamente puedes ejecutar:
+
+```bash
+python verify_admin_connection.py
+```
+
+El script imprime el ID de administrador configurado y la lista completa de administradores.
+Luego intenta enviar un mensaje de prueba al ID principal mostrando el resultado en la consola.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia [MIT](LICENSE).

--- a/verify_admin_connection.py
+++ b/verify_admin_connection.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Herramienta de diagnóstico para verificar la conexión con el administrador."""
+
+import telebot
+import config
+import dop
+
+
+def main():
+    print(f"ID de administrador configurado: {config.admin_id}")
+    admin_list = dop.get_adminlist()
+    print(f"Lista completa de administradores: {admin_list}")
+
+    bot = telebot.TeleBot(config.token)
+    try:
+        bot.send_message(config.admin_id, "✅ Conexión de prueba exitosa")
+        print("✅ Mensaje enviado correctamente")
+    except Exception as e:
+        print(f"❌ Error al enviar mensaje: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `verify_admin_connection.py` script
- explain how to run the script in a new "Depuración" section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870298ad5bc8333922fe91ade33733e