### PR TITLE
Add debug logs for admin branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ duplicadas.  Si el archivo existe y corresponde a un proceso activo, el bot se
 detendrá con una advertencia.  El archivo se elimina automáticamente al cerrar
 el bot.
 
-El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.
+El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.  Para
+ver mensajes más detallados establece la variable de entorno `LOGLEVEL` a `DEBUG` al ejecutarlo:
+
+```bash
+LOGLEVEL=DEBUG python main.py
+```
 
 Tras ello, los administradores deben escribir `/adm` para abrir el panel de administración. El comando solo está disponible para los IDs indicados en `TELEGRAM_ADMIN_ID` o en `data/lists/admins_list.txt`.
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,8 @@ import sys
 import time
 import logging
 
-logging.basicConfig(level=logging.INFO)
+LOGLEVEL = os.getenv("LOGLEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOGLEVEL, logging.INFO))
 
 # Files older than this many seconds will be removed from the Temp folder
 TEMP_FILE_MAX_AGE = 24 * 60 * 60  # 24 hours
@@ -170,15 +171,31 @@ def message_send(message):
 			
     elif '/adm' == message.text:
         admin_list = dop.get_adminlist()
+        logging.debug("Current admin_list: %s", admin_list)
+
         # Limpiar IDs que ya no son administradores
         for uid in list(in_admin):
             if uid not in admin_list:
                 in_admin.remove(uid)
+                logging.debug("Removed %s from in_admin", uid)
 
-        if message.chat.id in admin_list:
+        authorized = message.chat.id in admin_list
+        logging.debug(
+            "User %s requested admin mode. Authorized=%s",
+            message.chat.id,
+            authorized,
+        )
+
+        if authorized:
             if message.chat.id not in in_admin:
                 in_admin.append(message.chat.id)
-            adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
+                logging.debug("Added %s to in_admin", message.chat.id)
+            adminka.in_adminka(
+                message.chat.id,
+                message.text,
+                message.chat.username,
+                message.from_user.first_name,
+            )
         else:
             bot.send_message(message.chat.id, '❌ No tienes permisos de administrador')
 


### PR DESCRIPTION
## Summary
- allow setting LOGLEVEL env var for logging level
- add debug logs around admin mode to show admin list and user authorization
- document how to enable debug logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702ad8058c8333aa8ab3e00457bc44