### PR TITLE
Add admin panel button test

### DIFF
--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -41,3 +41,29 @@ def test_adm_command_allows_admin(monkeypatch, tmp_path):
     main.message_send(Msg())
 
     assert called.get('args') == (1, '/adm', 'admin', 'Admin')
+
+
+def test_admin_panel_button_dispatch(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+
+    called = {}
+
+    def fake_in_adminka(chat_id, text, username, name):
+        called['args'] = (chat_id, text, username, name)
+
+    monkeypatch.setattr(main.adminka, 'in_adminka', fake_in_adminka)
+    monkeypatch.setattr(dop, 'get_sost', lambda chat_id: False)
+    main.in_admin.append(1)
+
+    class Msg:
+        def __init__(self):
+            self.text = '⚙️ Configuración'
+            self.chat = types.SimpleNamespace(id=1, username='admin')
+            self.from_user = types.SimpleNamespace(first_name='Admin')
+            self.content_type = 'text'
+
+    main.message_send(Msg())
+
+    assert called.get('args') == (1, '⚙️ Configuración', 'admin', 'Admin')


### PR DESCRIPTION
## Summary
- expand admin access tests
- ensure that admin-panel button text triggers `adminka.in_adminka`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705e7889188333932c3b59fd5a61fc