### PR TITLE
Handle polling 409 conflict

### DIFF
--- a/main.py
+++ b/main.py
@@ -647,9 +647,23 @@ if __name__ == '__main__':
 
     logging.info("✅ Bot iniciando polling optimizado...")
     # Polling optimizado configurable mediante variables de entorno
-    bot.polling(
-        none_stop=True,
-        interval=config.POLL_INTERVAL,
-        timeout=config.POLL_TIMEOUT,
-        long_polling_timeout=config.LONG_POLLING_TIMEOUT
-    )
+    try:
+        bot.polling(
+            none_stop=True,
+            interval=config.POLL_INTERVAL,
+            timeout=config.POLL_TIMEOUT,
+            long_polling_timeout=config.LONG_POLLING_TIMEOUT
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        if (
+            getattr(e, "error_code", None) == 409
+            or "409" in str(e)
+            or "Conflict" in str(e)
+        ):
+            logging.error(
+                "⚠️ Se detectó un conflicto 409 al iniciar polling. "
+                "Es posible que otra instancia del bot esté activa. "
+                "Finaliza los otros procesos y borra data/bot.pid si es necesario."
+            )
+        else:
+            logging.exception("Error inesperado durante polling: %s", e)


### PR DESCRIPTION
## Summary
- handle other running bot processes when polling starts
- surface a helpful message if the Telegram API returns a 409 conflict

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68705f1fe9848333ade803e3077a7a34