### PR TITLE
Fix /report crash for blank messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -199,7 +199,7 @@ def message_send(message):
         else:
             bot.send_message(message.chat.id, '❌ No tienes permisos de administrador')
 
-    elif isinstance(message.text, str) and (
+    elif isinstance(message.text, str) and message.text.split() and (
         message.text.split()[0].lower()
         in ('/report', '/reporte', f'/report@{bot_username}', f'/reporte@{bot_username}')
     ):


### PR DESCRIPTION
## Summary
- avoid IndexError in `/report` handler when message text is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706228c858833398b9ba3151421282