### PR TITLE
Implement report forwarding

### DIFF
--- a/main.py
+++ b/main.py
@@ -271,6 +271,22 @@ def message_send(message):
                     bot.send_message(message.chat.id,
                                      '❌ **¡La cantidad debe ser un número válido!**\n\n🔢 Envía solo números (ej: 5)',
                                      parse_mode='Markdown', reply_markup=key)
+            elif sost_num == 23:
+                text = (message.text or '').strip()
+                if not text:
+                    return
+                username = f"@{message.chat.username}" if message.chat.username else ''
+                notification = f"Reporte de {username} ({message.chat.id}):\n{text}"
+                for admin_id in dop.get_adminlist():
+                    try:
+                        bot.send_message(admin_id, notification)
+                    except Exception as e:
+                        logging.error("Error enviando reporte a %s: %s", admin_id, e)
+                bot.send_message(message.chat.id, '✅ Reporte enviado a los administradores.')
+                with shelve.open(files.sost_bd) as bd:
+                    if str(message.chat.id) in bd:
+                        del bd[str(message.chat.id)]
+                send_main_menu(message.chat.id, message.chat.username, message.from_user.first_name)
 
     elif message.chat.id in in_admin:
         adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -36,3 +36,37 @@ def test_whitespace_message_ignored(monkeypatch, tmp_path):
     main.message_send(msg)
 
     assert not any('Por favor escribe tu reporte' in c[1][1] for c in calls if c[0] == 'send_message')
+
+
+def test_report_text_forwarded(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    os.makedirs('data/bd', exist_ok=True)
+    monkeypatch.setattr(main.files, 'sost_bd', str(tmp_path / 'sost.bd'))
+
+    with shelve.open(main.files.sost_bd) as bd:
+        bd['5'] = 23
+
+    monkeypatch.setattr(dop, 'get_adminlist', lambda: [99])
+
+    menu_called = {}
+
+    def fake_menu(chat_id, username, name):
+        menu_called['args'] = (chat_id, username, name)
+
+    monkeypatch.setattr(main, 'send_main_menu', fake_menu)
+
+    class Msg:
+        def __init__(self, text):
+            self.text = text
+            self.chat = types.SimpleNamespace(id=5, username='u')
+            self.from_user = types.SimpleNamespace(first_name='N')
+
+    msg = Msg('algo malo')
+    main.message_send(msg)
+
+    with shelve.open(main.files.sost_bd) as bd:
+        assert str(msg.chat.id) not in bd
+
+    assert any(c[0] == 'send_message' and c[1][0] == 99 for c in calls)
+    assert menu_called.get('args') == (5, 'u', 'N')


### PR DESCRIPTION
## Summary
- forward user reports to admins when in state `23`
- confirm report delivery, reset state and show main menu
- test that reports are forwarded and state cleared

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706eb766488333bfe685ac30ccd3e5