### PR TITLE
Switch to webhook server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,12 @@
 TELEGRAM_BOT_TOKEN=YOUR_BOT_TOKEN
 TELEGRAM_ADMIN_ID=YOUR_ADMIN_ID
+# Dirección pública completa del webhook, por ejemplo https://example.com/bot
+WEBHOOK_URL=
+WEBHOOK_PORT=8443
+WEBHOOK_LISTEN=0.0.0.0
+WEBHOOK_SSL_CERT=
+WEBHOOK_SSL_PRIV=
+WEBHOOK_SECRET_TOKEN=
 # Token utilizado por advertising_cron.py (obligatorio)
 # Puedes definir múltiples tokens separados por comas
 TELEGRAM_TOKEN=YOUR_ADVERTISING_TOKEN

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ pip install -r requirements.txt
    (o los tokens separados por comas) que empleará `advertising_cron.py`;
    el script fallará si no se configura esta variable.
 
-   Puedes modificar la frecuencia de consulta al servidor de Telegram
-   estableciendo las variables opcionales `POLL_INTERVAL`, `POLL_TIMEOUT`
-   y `LONG_POLLING_TIMEOUT`.  Si no las defines, el bot utiliza los valores
-   por defecto `2`, `10` y `10` segundos respectivamente.
+  Para ejecutar el bot mediante **webhook** debes definir en `.env`
+  la variable `WEBHOOK_URL` con la dirección pública que recibirá las
+  actualizaciones (por ejemplo `https://tu-dominio.com/bot`). También
+  puedes ajustar `WEBHOOK_PORT`, `WEBHOOK_LISTEN` y, si usas HTTPS con
+  certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`. Para mayor
+  seguridad puedes definir `WEBHOOK_SECRET_TOKEN` y Telegram enviará las
+  actualizaciones con el encabezado `X-Telegram-Bot-Api-Secret-Token`. El
+  servidor también expone un pequeño endpoint `/metrics` con estadísticas
+  básicas.
 
 ### Actualización
 
@@ -69,10 +74,11 @@ Luego puedes iniciar el bot con:
 python main.py
 ```
 
-Al iniciar, el proceso guarda su ID en `data/bot.pid` para evitar ejecuciones
-duplicadas.  Si el archivo existe y corresponde a un proceso activo, el bot se
-detendrá con una advertencia.  El archivo se elimina automáticamente al cerrar
-el bot.
+Este comando levanta un servidor Flask que escucha en `WEBHOOK_PORT` y registra
+el webhook definido en `WEBHOOK_URL`. Al iniciar, el proceso guarda su ID en
+`data/bot.pid` para evitar ejecuciones duplicadas. Si el archivo existe y
+corresponde a un proceso activo, el bot se detendrá con una advertencia. El
+archivo se elimina automáticamente al cerrar el bot.
 
 El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.  Para
 ver mensajes más detallados establece la variable de entorno `LOGLEVEL` a `DEBUG` al ejecutarlo:

--- a/config.py
+++ b/config.py
@@ -11,7 +11,21 @@ if not admin_id_env:
 admin_id = int(admin_id_env)
 token = os.getenv('TELEGRAM_BOT_TOKEN')
 
-# Parámetros opcionales para telebot.polling
+
+# Configuración para webhook
+WEBHOOK_URL = os.getenv('WEBHOOK_URL')
+WEBHOOK_PORT = int(os.getenv('WEBHOOK_PORT', '8443'))
+WEBHOOK_LISTEN = os.getenv('WEBHOOK_LISTEN', '0.0.0.0')
+WEBHOOK_SSL_CERT = os.getenv('WEBHOOK_SSL_CERT')
+WEBHOOK_SSL_PRIV = os.getenv('WEBHOOK_SSL_PRIV')
+WEBHOOK_SECRET_TOKEN = os.getenv('WEBHOOK_SECRET_TOKEN')
+if WEBHOOK_URL:
+    from urllib.parse import urlparse
+    WEBHOOK_PATH = urlparse(WEBHOOK_URL).path
+else:
+    WEBHOOK_PATH = f'/{token}'
+
+# Parámetros opcionales para telebot.polling (usados solo en modo polling)
 POLL_INTERVAL = int(os.getenv('POLL_INTERVAL', '2'))
 POLL_TIMEOUT = int(os.getenv('POLL_TIMEOUT', '10'))
 LONG_POLLING_TIMEOUT = int(os.getenv('LONG_POLLING_TIMEOUT', '10'))

--- a/main.py
+++ b/main.py
@@ -656,6 +656,55 @@ def handle_media_files(message):
     """Manejar archivos multimedia (fotos, videos, audio, GIF)"""
     adminka.handle_multimedia(message)
 
+def run_webhook():
+    """Iniciar el bot usando webhook con Flask."""
+    import flask
+
+    app = flask.Flask(__name__)
+    metrics = {"updates": 0}
+
+    @app.route(config.WEBHOOK_PATH, methods=['POST'])
+    def webhook():
+        if config.WEBHOOK_SECRET_TOKEN:
+            secret = flask.request.headers.get('X-Telegram-Bot-Api-Secret-Token')
+            if secret != config.WEBHOOK_SECRET_TOKEN:
+                logging.warning("Token secreto inválido desde %s", flask.request.remote_addr)
+                return flask.abort(403)
+
+        if flask.request.headers.get('content-type') != 'application/json':
+            logging.warning("Tipo de contenido no soportado: %s", flask.request.headers.get('content-type'))
+            return flask.abort(415)
+
+        try:
+            data = flask.request.get_data().decode('utf-8')
+            update = telebot.types.Update.de_json(data)
+        except Exception as e:  # pylint: disable=broad-except
+            logging.exception("Error al deserializar actualización: %s", e)
+            return flask.abort(400)
+
+        try:
+            bot.process_new_updates([update])
+            metrics["updates"] += 1
+        except Exception as e:  # pylint: disable=broad-except
+            logging.exception("Error procesando actualización: %s", e)
+        return ""
+
+    @app.route('/metrics')
+    def metrics_route():
+        return flask.jsonify(metrics)
+
+    bot.remove_webhook()
+    time.sleep(0.1)
+    bot.set_webhook(url=config.WEBHOOK_URL, secret_token=config.WEBHOOK_SECRET_TOKEN)
+
+    ctx = None
+    if config.WEBHOOK_SSL_CERT and config.WEBHOOK_SSL_PRIV:
+        ctx = (config.WEBHOOK_SSL_CERT, config.WEBHOOK_SSL_PRIV)
+
+    logging.info("Webhook escuchando en %s:%s%s", config.WEBHOOK_LISTEN, config.WEBHOOK_PORT, config.WEBHOOK_PATH)
+    app.run(host=config.WEBHOOK_LISTEN, port=config.WEBHOOK_PORT, ssl_context=ctx)
+
+
 if __name__ == '__main__':
     if is_running():
         logging.error("⚠️ Bot ya está ejecutándose (data/bot.pid)")
@@ -667,25 +716,5 @@ if __name__ == '__main__':
     except Exception:
         logging.error("⚠️ No se pudo escribir data/bot.pid")
 
-    logging.info("✅ Bot iniciando polling optimizado...")
-    # Polling optimizado configurable mediante variables de entorno
-    try:
-        bot.polling(
-            none_stop=True,
-            interval=config.POLL_INTERVAL,
-            timeout=config.POLL_TIMEOUT,
-            long_polling_timeout=config.LONG_POLLING_TIMEOUT
-        )
-    except Exception as e:  # pylint: disable=broad-except
-        if (
-            getattr(e, "error_code", None) == 409
-            or "409" in str(e)
-            or "Conflict" in str(e)
-        ):
-            logging.error(
-                "⚠️ Se detectó un conflicto 409 al iniciar polling. "
-                "Es posible que otra instancia del bot esté activa. "
-                "Finaliza los otros procesos y borra data/bot.pid si es necesario."
-            )
-        else:
-            logging.exception("Error inesperado durante polling: %s", e)
+    logging.info("✅ Bot iniciando en modo webhook...")
+    run_webhook()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ python-dotenv
 paypalrestsdk
 python-binance
 requests
+Flask
 
 pytest


### PR DESCRIPTION
## Summary
- add webhook configuration variables
- document webhook usage in README and .env.example
- add Flask to requirements
- run the bot via webhook instead of polling
- improve webhook security and add metrics endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706cd4bfd48333b9a5e7f479469d9e