### PR TITLE
Implement webhook startup with metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ pip install -r requirements.txt
    (o los tokens separados por comas) que empleará `advertising_cron.py`;
    el script fallará si no se configura esta variable.
 
-  Para ejecutar el bot mediante **webhook** debes definir en `.env`
-  la variable `WEBHOOK_URL` con la dirección pública que recibirá las
+  Para ejecutar el bot mediante **webhook** define en `.env` la
+  variable `WEBHOOK_URL` con la dirección pública que recibirá las
   actualizaciones (por ejemplo `https://tu-dominio.com/bot`). También
   puedes ajustar `WEBHOOK_PORT`, `WEBHOOK_LISTEN` y, si usas HTTPS con
-  certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`.
+  certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`.  Si
+  `WEBHOOK_URL` queda vacío el bot se ejecutará en modo *polling*.
 
 ### Actualización
 
@@ -74,7 +75,10 @@ Este comando levanta un servidor Flask que escucha en `WEBHOOK_PORT` y registra
 el webhook definido en `WEBHOOK_URL`. Al iniciar, el proceso guarda su ID en
 `data/bot.pid` para evitar ejecuciones duplicadas. Si el archivo existe y
 corresponde a un proceso activo, el bot se detendrá con una advertencia. El
-archivo se elimina automáticamente al cerrar el bot.
+archivo se elimina automáticamente al cerrar el bot. Además, el servidor expone
+la ruta `/metrics` que puede usarse para comprobar el estado del bot.
+Si `WEBHOOK_URL` se deja vacío, el bot funcionará mediante *polling* en
+intervalos definidos por `POLL_INTERVAL`.
 
 El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.  Para
 ver mensajes más detallados establece la variable de entorno `LOGLEVEL` a `DEBUG` al ejecutarlo:

--- a/main.py
+++ b/main.py
@@ -671,6 +671,10 @@ def run_webhook():
             return ''
         return flask.abort(403)
 
+    @app.route('/metrics', methods=['GET'])
+    def metrics():
+        return 'ok'
+
     bot.remove_webhook()
     time.sleep(0.1)
     bot.set_webhook(url=config.WEBHOOK_URL)
@@ -680,6 +684,16 @@ def run_webhook():
         ctx = (config.WEBHOOK_SSL_CERT, config.WEBHOOK_SSL_PRIV)
 
     app.run(host=config.WEBHOOK_LISTEN, port=config.WEBHOOK_PORT, ssl_context=ctx)
+
+
+def run_polling():
+    """Iniciar el bot usando long polling."""
+    bot.remove_webhook()
+    bot.infinity_polling(
+        interval=config.POLL_INTERVAL,
+        timeout=config.POLL_TIMEOUT,
+        long_polling_timeout=config.LONG_POLLING_TIMEOUT,
+    )
 
 
 if __name__ == '__main__':
@@ -693,5 +707,9 @@ if __name__ == '__main__':
     except Exception:
         logging.error("⚠️ No se pudo escribir data/bot.pid")
 
-    logging.info("✅ Bot iniciando en modo webhook...")
-    run_webhook()
+    if config.WEBHOOK_URL:
+        logging.info("✅ Bot iniciando en modo webhook...")
+        run_webhook()
+    else:
+        logging.info("✅ Bot iniciando en modo polling...")
+        run_polling()


### PR DESCRIPTION
## Summary
- allow fallback to polling when WEBHOOK_URL is not set
- expose `/metrics` endpoint under webhook
- document webhook variables and metrics endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707939318483339fb9946ba22474dc