### PR TITLE
Add webhook URL check and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ pip install -r requirements.txt
   puedes ajustar `WEBHOOK_PORT`, `WEBHOOK_LISTEN` y, si usas HTTPS con
   certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`.  Si
   `WEBHOOK_URL` queda vacío el bot se ejecutará en modo *polling*.
+  Ten en cuenta que el modo webhook requiere que `WEBHOOK_URL` tenga un
+  valor; de lo contrario `run_webhook()` finalizará con un error.
 
 ### Actualización
 
@@ -79,6 +81,8 @@ archivo se elimina automáticamente al cerrar el bot. Además, el servidor expon
 la ruta `/metrics` que puede usarse para comprobar el estado del bot.
 Si `WEBHOOK_URL` se deja vacío, el bot funcionará mediante *polling* en
 intervalos definidos por `POLL_INTERVAL`.
+Si intentas iniciar `run_webhook()` sin definir `WEBHOOK_URL`, el proceso
+terminará con un mensaje de error.
 
 El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.  Para
 ver mensajes más detallados establece la variable de entorno `LOGLEVEL` a `DEBUG` al ejecutarlo:

--- a/main.py
+++ b/main.py
@@ -658,6 +658,10 @@ def handle_media_files(message):
 
 def run_webhook():
     """Iniciar el bot usando webhook con Flask."""
+    if not config.WEBHOOK_URL:
+        logging.error("WEBHOOK_URL must be set to run in webhook mode.")
+        sys.exit(1)
+
     import flask
 
     app = flask.Flask(__name__)

--- a/tests/test_webhook_mode.py
+++ b/tests/test_webhook_mode.py
@@ -1,0 +1,10 @@
+import pytest
+from tests.test_shop_info import setup_main
+
+
+def test_run_webhook_requires_url(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    monkeypatch.setattr(main.config, "WEBHOOK_URL", "")
+    with pytest.raises(SystemExit) as exc:
+        main.run_webhook()
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- enforce webhook URL presence in `run_webhook`
- document webhook URL requirement in README
- add test verifying failure when no `WEBHOOK_URL`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707cf5c7b08333900a7074e547cff7