### PR TITLE
Add tests for webhook server

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,50 @@
+import json
+from tests.test_shop_info import setup_main
+import webhook_server
+
+
+def setup_app(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    monkeypatch.setattr(main.config, "WEBHOOK_SECRET_TOKEN", "secret")
+    # Reset metrics for each test
+    monkeypatch.setattr(webhook_server, "metrics", {"requests_total": 0, "updates_total": 0}, raising=False)
+    app = webhook_server.create_app()
+    return app, webhook_server, calls, bot, main
+
+
+def test_valid_update(monkeypatch, tmp_path):
+    app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    client = app.test_client()
+    update = {"update_id": 1}
+    before = server.metrics.copy()
+    resp = client.post(main.config.WEBHOOK_PATH, json=update, headers={"X-Telegram-Bot-Api-Secret-Token": "secret"})
+    assert resp.status_code == 200
+    assert any(c[0] == "process_new_updates" for c in calls)
+    assert server.metrics["updates_total"] == before["updates_total"] + 1
+    assert server.metrics["requests_total"] == before["requests_total"] + 1
+
+
+def test_invalid_secret(monkeypatch, tmp_path):
+    app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    client = app.test_client()
+    update = {"update_id": 1}
+    before = server.metrics.copy()
+    resp = client.post(main.config.WEBHOOK_PATH, json=update, headers={"X-Telegram-Bot-Api-Secret-Token": "bad"})
+    assert resp.status_code == 403
+    assert not any(c[0] == "process_new_updates" for c in calls)
+    assert server.metrics["updates_total"] == before["updates_total"]
+    assert server.metrics["requests_total"] == before["requests_total"] + 1
+
+
+def test_invalid_content_type(monkeypatch, tmp_path):
+    app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    client = app.test_client()
+    before = server.metrics.copy()
+    resp = client.post(main.config.WEBHOOK_PATH, data="notjson", headers={"X-Telegram-Bot-Api-Secret-Token": "secret"})
+    assert resp.status_code == 415
+    assert not any(c[0] == "process_new_updates" for c in calls)
+    assert server.metrics["updates_total"] == before["updates_total"]
+    assert server.metrics["requests_total"] == before["requests_total"] + 1

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -1,0 +1,34 @@
+from flask import Flask, request, abort
+import telebot
+import config
+from bot_instance import bot
+
+# Simple in-memory metrics
+metrics = {
+    "requests_total": 0,
+    "updates_total": 0,
+}
+
+
+def create_app():
+    app = Flask(__name__)
+    secret = getattr(config, "WEBHOOK_SECRET_TOKEN", None)
+
+    @app.route(config.WEBHOOK_PATH, methods=["POST"])
+    def webhook():
+        metrics["requests_total"] += 1
+        if request.headers.get("content-type") != "application/json":
+            return "", 415
+        if secret and request.headers.get("X-Telegram-Bot-Api-Secret-Token") != secret:
+            return "", 403
+        data = request.get_json()
+        update = telebot.types.Update.de_json(data)
+        bot.process_new_updates([update])
+        metrics["updates_total"] += 1
+        return ""
+
+    @app.route("/metrics", methods=["GET"])
+    def metrics_route():
+        return "ok"
+
+    return app


### PR DESCRIPTION
## Summary
- implement a simple `webhook_server` module with token checking
- add `tests/test_webhook_server.py` to verify webhook behaviour

## Testing
- `pytest -k webhook_server -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install Flask` *(fails due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_68707e24e23c83338fa9ede058f597cb