### PR TITLE
Validate webhook url

### DIFF
--- a/main.py
+++ b/main.py
@@ -659,8 +659,9 @@ def handle_media_files(message):
 def run_webhook():
     """Iniciar el bot usando webhook con Flask."""
     if not config.WEBHOOK_URL:
-        logging.error("WEBHOOK_URL must be set to run in webhook mode.")
-        sys.exit(1)
+        raise RuntimeError(
+            "WEBHOOK_URL must be set in .env to run in webhook mode."
+        )
 
     import flask
 

--- a/tests/test_webhook_mode.py
+++ b/tests/test_webhook_mode.py
@@ -5,6 +5,5 @@ from tests.test_shop_info import setup_main
 def test_run_webhook_requires_url(monkeypatch, tmp_path):
     dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
     monkeypatch.setattr(main.config, "WEBHOOK_URL", "")
-    with pytest.raises(SystemExit) as exc:
+    with pytest.raises(RuntimeError):
         main.run_webhook()
-    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- raise a `RuntimeError` when starting webhook mode without `WEBHOOK_URL`
- expect the error in webhook-mode test

## Testing
- `pytest -q tests/test_webhook_mode.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687080f039848333882464a1baac392d