### PR TITLE
Require WEBHOOK_URL and add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ pip install -r requirements.txt
   variable `WEBHOOK_URL` con la dirección pública que recibirá las
   actualizaciones (por ejemplo `https://tu-dominio.com/bot`). También
   puedes ajustar `WEBHOOK_PORT`, `WEBHOOK_LISTEN` y, si usas HTTPS con
-  certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`.  Si
-  `WEBHOOK_URL` queda vacío el bot se ejecutará en modo *polling*.
-  Ten en cuenta que el modo webhook requiere que `WEBHOOK_URL` tenga un
-  valor; de lo contrario `run_webhook()` finalizará con un error.
+  certificados propios, `WEBHOOK_SSL_CERT` y `WEBHOOK_SSL_PRIV`.
+  **El bot no iniciará a menos que proporciones `WEBHOOK_URL`.** La
+  configuración lanzará un `RuntimeError` y `run_webhook()` finalizará
+  con un error si esta variable queda vacía.
 
 ### Actualización
 
@@ -79,10 +79,8 @@ el webhook definido en `WEBHOOK_URL`. Al iniciar, el proceso guarda su ID en
 corresponde a un proceso activo, el bot se detendrá con una advertencia. El
 archivo se elimina automáticamente al cerrar el bot. Además, el servidor expone
 la ruta `/metrics` que puede usarse para comprobar el estado del bot.
-Si `WEBHOOK_URL` se deja vacío, el bot funcionará mediante *polling* en
-intervalos definidos por `POLL_INTERVAL`.
-Si intentas iniciar `run_webhook()` sin definir `WEBHOOK_URL`, el proceso
-terminará con un mensaje de error.
+El valor de `WEBHOOK_URL` es obligatorio: si se deja vacío, la carga de
+`config.py` lanzará un `RuntimeError` antes de iniciar el servidor.
 
 El bot mostrará mensajes de depuración y podrás configurarlo enviando `/start` desde la cuenta de administrador.  Para
 ver mensajes más detallados establece la variable de entorno `LOGLEVEL` a `DEBUG` al ejecutarlo:

--- a/config.py
+++ b/config.py
@@ -14,6 +14,8 @@ token = os.getenv('TELEGRAM_BOT_TOKEN')
 
 # Configuración para webhook
 WEBHOOK_URL = os.getenv('WEBHOOK_URL')
+if not WEBHOOK_URL:
+    raise RuntimeError("WEBHOOK_URL must be set for webhook mode")
 WEBHOOK_PORT = int(os.getenv('WEBHOOK_PORT', '8443'))
 WEBHOOK_LISTEN = os.getenv('WEBHOOK_LISTEN', '0.0.0.0')
 WEBHOOK_SSL_CERT = os.getenv('WEBHOOK_SSL_CERT')

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -5,6 +5,7 @@ from pathlib import Path
 def setup_main(monkeypatch, tmp_path):
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
     monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+    monkeypatch.setenv("WEBHOOK_URL", "https://example.com/bot")
     sys.modules.setdefault(
         "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
     )
@@ -50,7 +51,8 @@ def setup_main(monkeypatch, tmp_path):
     telebot_stub = types.SimpleNamespace(TeleBot=lambda *a, **k: Bot(),
                                          types=types.SimpleNamespace(
                                              InlineKeyboardMarkup=Markup,
-                                             InlineKeyboardButton=Button))
+                                             InlineKeyboardButton=Button,
+                                             Update=types.SimpleNamespace(de_json=lambda d: d)))
     sys.modules["telebot"] = telebot_stub
     bot = telebot_stub.TeleBot()
     sys.modules["bot_instance"] = types.SimpleNamespace(bot=bot)

--- a/tests/test_webhook_config.py
+++ b/tests/test_webhook_config.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+import types
+import pytest
+
+
+def test_import_requires_webhook_url(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    monkeypatch.setenv("TELEGRAM_ADMIN_ID", "1")
+    monkeypatch.delenv("WEBHOOK_URL", raising=False)
+    sys.modules.setdefault(
+        "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+    )
+    sys.modules.pop("config", None)
+    with pytest.raises(RuntimeError):
+        importlib.import_module("config")

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,11 +1,82 @@
 import json
+import sys
+import types
 from tests.test_shop_info import setup_main
+
+sys.modules.setdefault(
+    "dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None)
+)
+sys.modules.setdefault(
+    "telebot",
+    types.SimpleNamespace(
+        types=types.SimpleNamespace(Update=types.SimpleNamespace(de_json=lambda d: d)),
+        TeleBot=lambda *a, **k: types.SimpleNamespace(),
+    ),
+)
+os = __import__("os")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "x")
+os.environ.setdefault("TELEGRAM_ADMIN_ID", "1")
+os.environ.setdefault("WEBHOOK_URL", "https://example.com/bot")
+
+try:
+    import flask  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal env
+    request = types.SimpleNamespace(headers={}, get_json=lambda: None)
+
+    class App:
+        def __init__(self, *a, **k):
+            self.routes = {}
+
+        def route(self, path, methods=None):
+            def decorator(func):
+                self.routes[(path, tuple(methods or ["GET"]))] = func
+                return func
+            return decorator
+
+        def test_client(self):
+            app = self
+
+            class Client:
+                def post(self, path, json=None, data=None, headers=None):
+                    if json is not None:
+                        hdrs = {"content-type": "application/json"}
+                        if headers:
+                            hdrs.update(headers)
+                        request.headers = hdrs
+                        request.get_json = lambda: json
+                    else:
+                        request.headers = headers or {}
+                        request.get_json = lambda: data
+                    resp = app.routes[(path, ("POST",))]()
+                    if isinstance(resp, tuple):
+                        status = resp[1]
+                    else:
+                        status = 200
+                    return types.SimpleNamespace(status_code=status)
+
+                def get(self, path, headers=None):
+                    request.headers = headers or {}
+                    resp = app.routes[(path, ("GET",))]()
+                    if isinstance(resp, tuple):
+                        status = resp[1]
+                    else:
+                        status = 200
+                    return types.SimpleNamespace(status_code=status)
+
+            return Client()
+
+    flask = types.SimpleNamespace(Flask=App, request=request, abort=lambda c: ("", c))
+    sys.modules.setdefault("flask", flask)
+
 import webhook_server
 
 
 def setup_app(monkeypatch, tmp_path):
     dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
-    monkeypatch.setattr(main.config, "WEBHOOK_SECRET_TOKEN", "secret")
+    monkeypatch.setattr(main.config, "WEBHOOK_SECRET_TOKEN", "secret", raising=False)
+    monkeypatch.setattr(webhook_server.config, "WEBHOOK_SECRET_TOKEN", "secret", raising=False)
+    monkeypatch.setattr(webhook_server, "telebot", sys.modules["telebot"], raising=False)
+    monkeypatch.setattr(webhook_server, "bot", bot, raising=False)
     # Reset metrics for each test
     monkeypatch.setattr(webhook_server, "metrics", {"requests_total": 0, "updates_total": 0}, raising=False)
     app = webhook_server.create_app()
@@ -14,7 +85,7 @@ def setup_app(monkeypatch, tmp_path):
 
 def test_valid_update(monkeypatch, tmp_path):
     app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
-    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)), raising=False)
     client = app.test_client()
     update = {"update_id": 1}
     before = server.metrics.copy()
@@ -27,7 +98,7 @@ def test_valid_update(monkeypatch, tmp_path):
 
 def test_invalid_secret(monkeypatch, tmp_path):
     app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
-    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)), raising=False)
     client = app.test_client()
     update = {"update_id": 1}
     before = server.metrics.copy()
@@ -40,7 +111,7 @@ def test_invalid_secret(monkeypatch, tmp_path):
 
 def test_invalid_content_type(monkeypatch, tmp_path):
     app, server, calls, bot, main = setup_app(monkeypatch, tmp_path)
-    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)))
+    monkeypatch.setattr(bot, "process_new_updates", lambda updates: calls.append(("process_new_updates", updates)), raising=False)
     client = app.test_client()
     before = server.metrics.copy()
     resp = client.post(main.config.WEBHOOK_PATH, data="notjson", headers={"X-Telegram-Bot-Api-Secret-Token": "secret"})


### PR DESCRIPTION
## Summary
- ensure `WEBHOOK_URL` is defined when loading configuration
- document mandatory `WEBHOOK_URL` in README
- set `WEBHOOK_URL` in test helpers
- create test verifying `config` fails when `WEBHOOK_URL` is missing
- provide lightweight flask/telebot stubs for webhook server tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687082cbac44833386cfc89b9b874829