### PR TITLE
Handle returning user shop selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Desde ese menú también podrás pulsar **"Mis compras"** para revisar un resume
 
 El bot admite gestionar varias tiendas. El usuario cuyo ID figura en `TELEGRAM_ADMIN_ID` es el *super admin* y posee un menú adicional **🛍️ Gestionar tiendas** dentro de **⚙️ Otros**. Solo este super admin puede añadir o eliminar otros administradores.
 
-Desde allí puede crear nuevas tiendas y asignar el ID de Telegram de su administrador. Cada cliente, al enviar `/start`, verá la lista de tiendas disponibles y deberá elegir una para acceder al catálogo. Su elección se guarda para futuras visitas.
+Desde allí puede crear nuevas tiendas y asignar el ID de Telegram de su administrador. Cada cliente, al enviar `/start`, verá la lista de tiendas disponibles y deberá elegir una para acceder al catálogo. Su elección se guarda para futuras visitas. Si un usuario ya tiene tienda asignada, `/start` lo lleva directamente al menú principal.
 
 Cada administrador puede renombrar su tienda desde **⚙️ Otros** usando la opción *Cambiar nombre de tienda*.
 

--- a/dop.py
+++ b/dop.py
@@ -1158,6 +1158,20 @@ def get_user_shop(user_id):
         logging.error(f"Error getting user shop: {e}")
         return 1
 
+def user_has_shop(user_id):
+    """Return True if the user already selected a shop."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "SELECT 1 FROM shop_users WHERE user_id = ?",
+            (int(user_id),),
+        )
+        return cur.fetchone() is not None
+    except Exception as e:
+        logging.error(f"Error checking user shop: {e}")
+        return False
+
 def submit_shop_rating(shop_id, user_id, rating):
     """Insertar o actualizar la calificación de un usuario para una tienda."""
     try:

--- a/main.py
+++ b/main.py
@@ -160,7 +160,14 @@ def message_send(message):
                     '🚧 **¡El bot aún no está listo para funcionar!**\n\n🔧 Si eres el administrador, entra con la cuenta cuyo ID especificaste al iniciar el bot y prepáralo para funcionar!',
                     parse_mode='Markdown')
             else:
-                show_shop_selection(message.chat.id)
+                if dop.user_has_shop(message.chat.id):
+                    send_main_menu(
+                        message.chat.id,
+                        message.chat.username,
+                        message.from_user.first_name,
+                    )
+                else:
+                    show_shop_selection(message.chat.id)
 
             dop.user_loger(chat_id=message.chat.id)
 

--- a/tests/test_start_welcome.py
+++ b/tests/test_start_welcome.py
@@ -1,0 +1,73 @@
+import types
+from tests.test_shop_info import setup_main
+
+
+def test_start_existing_user_main_menu(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.set_user_shop(5, sid)
+
+    monkeypatch.setattr(dop, "it_first", lambda uid: False)
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(dop, "get_sost", lambda cid: False)
+    monkeypatch.setattr(dop, "user_loger", lambda chat_id=0: None)
+
+    called = {}
+
+    def fake_menu(cid, username, name):
+        called["menu"] = (cid, username, name)
+
+    def fake_select(cid):
+        called["select"] = cid
+
+    monkeypatch.setattr(main, "send_main_menu", fake_menu)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
+
+    class Msg:
+        def __init__(self):
+            self.text = "/start"
+            self.chat = types.SimpleNamespace(id=5, username="u")
+            self.from_user = types.SimpleNamespace(first_name="N")
+            self.content_type = "text"
+
+    main.message_send(Msg())
+
+    assert called.get("menu") == (5, "u", "N")
+    assert "select" not in called
+
+
+def test_start_new_user_shows_shop_list(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    dop.create_shop("S1", admin_id=1)
+
+    monkeypatch.setattr(dop, "it_first", lambda uid: False)
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(dop, "get_sost", lambda cid: False)
+    monkeypatch.setattr(dop, "user_loger", lambda chat_id=0: None)
+
+    called = {}
+
+    def fake_menu(cid, username, name):
+        called["menu"] = (cid, username, name)
+
+    def fake_select(cid):
+        called["select"] = cid
+
+    monkeypatch.setattr(main, "send_main_menu", fake_menu)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
+
+    class Msg:
+        def __init__(self):
+            self.text = "/start"
+            self.chat = types.SimpleNamespace(id=5, username="u")
+            self.from_user = types.SimpleNamespace(first_name="N")
+            self.content_type = "text"
+
+    main.message_send(Msg())
+
+    assert called.get("select") == 5
+    assert "menu" not in called


### PR DESCRIPTION
## Summary
- add `user_has_shop` helper to check if user already selected a shop
- show main menu on `/start` when user previously chose a shop
- test `/start` behaviour depending on `shop_users` table
- document new behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870adedff4c83339cc7e75837d66a66