### PR TITLE
Fix shop default assignment

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -406,9 +406,10 @@ def user_loger(chat_id=0):
             with open(files.users_list, 'w', encoding='utf-8') as f:
                 f.write(str(chat_id) + '\n')
         try:
-            # Registrar o actualizar la tienda del usuario
-            current = get_user_shop(chat_id)
-            set_user_shop(chat_id, current)
+            # Registrar o actualizar la tienda del usuario solo si ya existe
+            if user_has_shop(chat_id):
+                current = get_user_shop(chat_id)
+                set_user_shop(chat_id, current)
         except Exception as e:
             logging.error(f"Error updating user shop: {e}")
 

--- a/tests/test_start_welcome.py
+++ b/tests/test_start_welcome.py
@@ -71,3 +71,45 @@ def test_start_new_user_shows_shop_list(monkeypatch, tmp_path):
 
     assert called.get("select") == 5
     assert "menu" not in called
+
+
+def test_start_new_user_keeps_showing_list(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    dop.create_shop("S1", admin_id=1)
+
+    monkeypatch.setattr(dop, "it_first", lambda uid: False)
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(dop, "get_sost", lambda cid: False)
+    users_file = tmp_path / "users.txt"
+    monkeypatch.setattr(dop.files, "users_list", str(users_file))
+
+    called = []
+
+    def fake_menu(cid, username, name):
+        called.append(("menu", cid))
+
+    def fake_select(cid):
+        called.append(("select", cid))
+
+    monkeypatch.setattr(main, "send_main_menu", fake_menu)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
+
+    class Msg:
+        def __init__(self):
+            self.text = "/start"
+            self.chat = types.SimpleNamespace(id=5, username="u")
+            self.from_user = types.SimpleNamespace(first_name="N")
+            self.content_type = "text"
+
+    main.message_send(Msg())
+    assert called == [("select", 5)]
+    assert not dop.user_has_shop(5)
+
+    called.clear()
+    main.message_send(Msg())
+
+    assert called == [("select", 5)]
+    assert not dop.user_has_shop(5)
+


### PR DESCRIPTION
## Summary
- avoid inserting default shop in `user_loger`
- test that `/start` continues to show the shop list for undecided users

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b203bfd083339fcbfafddbb5bade