### PR TITLE
Add shop change option

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,6 +74,7 @@ def send_main_menu(chat_id, username, name):
     key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
     key.add(telebot.types.InlineKeyboardButton(
         text='📜 Mis compras', callback_data='Ver mis compras'))
+    key.add(telebot.types.InlineKeyboardButton(text='Cambiar tienda', callback_data='Cambiar tienda'))
     if dop.check_message('start'):
         with shelve.open(files.bot_message_bd) as bd:
             start_message = bd['start']
@@ -539,6 +540,9 @@ def inline(callback):
             bot.answer_callback_query(callback.id)
             dop.safe_edit_message(bot, callback.message,
                                   history, reply_markup=key, parse_mode='Markdown')
+        elif callback.data == 'Cambiar tienda':
+            bot.answer_callback_query(callback.id)
+            show_shop_selection(callback.message.chat.id)
 
 
         elif callback.data == 'Volver al inicio':

--- a/tests/test_change_shop.py
+++ b/tests/test_change_shop.py
@@ -1,0 +1,57 @@
+import types
+from tests.test_shop_info import setup_main
+
+
+def test_main_menu_has_change_button(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    main.send_main_menu(5, 'u', 'N')
+    buttons = calls[-1][2]["reply_markup"].buttons
+    assert any('Cambiar tienda' in b.text for b in buttons)
+
+
+def test_change_shop_callback_invokes_list(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    called = {}
+
+    def fake_select(cid):
+        called['cid'] = cid
+
+    monkeypatch.setattr(main, 'show_shop_selection', fake_select)
+    monkeypatch.setattr(main.bot, 'answer_callback_query', lambda *a, **k: None, raising=False)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5)
+            self.message_id = 1
+            self.content_type = 'text'
+            self.from_user = types.SimpleNamespace(first_name='a')
+
+    cb = types.SimpleNamespace(data='Cambiar tienda', message=Msg(), id='1', from_user=types.SimpleNamespace(username='u'))
+    main.inline(cb)
+
+    assert called.get('cid') == 5
+
+
+def test_reselect_updates_shop(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    sid1 = dop.create_shop('S1', admin_id=1)
+    sid2 = dop.create_shop('S2', admin_id=1)
+    dop.set_user_shop(5, sid1)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5)
+            self.message_id = 1
+            self.content_type = 'text'
+            self.from_user = types.SimpleNamespace(first_name='a')
+
+    cb = types.SimpleNamespace(data=f'SELECT_SHOP_{sid2}', message=Msg(), id='2', from_user=types.SimpleNamespace(username='u'))
+    main.inline(cb)
+
+    assert dop.get_user_shop(5) == sid2


### PR DESCRIPTION
## Summary
- allow changing the selected shop from main menu
- handle `Cambiar tienda` callback to reuse shop selection
- test change shop functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b3318e388333a26cba115fbcecf1