### PR TITLE
Add shop switch button on home return

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ Esto creará la tabla `shop_users` necesaria para las difusiones por tienda.
 
 Al crear una tienda se solicitará un nombre, el cual verán los clientes al elegir tienda después de enviar `/start`. Los administradores pueden cambiar este nombre más adelante desde **⚙️ Otros** → **✏️ Renombrar tienda**.
 
+### Presentación de la tienda
+
+Para ajustar la información que se muestra al entrar a una tienda abre el **menú de administración** y selecciona **⚙️ Otros**. Allí encontrarás las opciones:
+
+- *Cambiar nombre de tienda*
+- *Cambiar descripción de tienda*
+- *Cambiar multimedia de tienda*
+- *Cambiar botones de tienda*
+
 ## Panel de administración
 
 Al entrar verás botones para gestionar las distintas funciones del bot. Entre
@@ -129,8 +138,7 @@ En **💬 Respuestas** puedes definir distintos textos que el bot enviará. Se a
 **Agregar/Cambiar mensaje de entrega manual**, utilizado cuando un producto requiere
 entrega manual. En ese mensaje puedes incluir las palabras `username` y `name` para
 personalizarlo. Configurar **💬 Respuestas** es un privilegio exclusivo del super admin.
-Además, la bienvenida al usuario ahora admite multimedia. Al elegir *Añadir/Cambiar bienvenida al usuario* puedes
-subir una foto, video o documento opcional que se enviará junto al texto de bienvenida.
+Además, la bienvenida al usuario ahora admite multimedia. Para cambiarla abre el **menú de administración** y entra en **💬 Respuestas** → **Cambiar bienvenida al usuario**. Allí puedes escribir el mensaje y, opcionalmente, adjuntar una foto, video o documento.
 
 ### Carga y edición de unidades
 

--- a/main.py
+++ b/main.py
@@ -551,36 +551,11 @@ def inline(callback):
                     with shelve.open(files.sost_bd) as bd:
                         if str(callback.message.chat.id) in bd:
                             del bd[str(callback.message.chat.id)]
-                key = telebot.types.InlineKeyboardMarkup()
-                key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
-                key.add(telebot.types.InlineKeyboardButton(
-                    text='📜 Mis compras', callback_data='Ver mis compras'))
-                if dop.check_message('start'):
-                    with shelve.open(files.bot_message_bd) as bd:
-                        start_message = bd['start']
-                    start_message = start_message.replace('username', callback.message.chat.username)
-                    start_message = start_message.replace('name', callback.message.from_user.first_name)
-                    media = dop.get_start_media()
-                    if media:
-                        bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                        if media['type'] == 'photo':
-                            bot.send_photo(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
-                        elif media['type'] == 'video':
-                            bot.send_video(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
-                        elif media['type'] == 'document':
-                            bot.send_document(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
-                        elif media['type'] == 'audio':
-                            bot.send_audio(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
-                        elif media['type'] == 'animation':
-                            bot.send_animation(callback.message.chat.id, media['file_id'], caption=start_message, reply_markup=key)
-                        else:
-                            bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
-                    else:
-                        if callback.message.content_type != 'text':
-                            bot.delete_message(callback.message.chat.id, callback.message.message_id)
-                            bot.send_message(callback.message.chat.id, start_message, reply_markup=key)
-                        else:
-                            dop.safe_edit_message(bot, callback.message, start_message, reply_markup=key)
+                send_main_menu(
+                    callback.message.chat.id,
+                    callback.message.chat.username,
+                    callback.message.from_user.first_name,
+                )
 
         elif callback.data == 'Comprar':
             try:

--- a/tests/test_home_button.py
+++ b/tests/test_home_button.py
@@ -1,0 +1,30 @@
+from tests.test_shop_info import setup_main
+import types
+
+
+def test_home_button_calls_main_menu(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    sid = dop.create_shop('S1', admin_id=1)
+    dop.set_user_shop(5, sid)
+
+    called = {}
+
+    def fake_menu(cid, username, name):
+        called['menu'] = (cid, username, name)
+
+    monkeypatch.setattr(main, 'send_main_menu', fake_menu)
+    monkeypatch.setattr(main.bot, 'answer_callback_query', lambda *a, **k: None, raising=False)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5, username='u')
+            self.message_id = 1
+            self.content_type = 'text'
+            self.from_user = types.SimpleNamespace(first_name='N')
+
+    cb = types.SimpleNamespace(data='Volver al inicio', message=Msg(), id='1', from_user=types.SimpleNamespace(username='u'))
+    main.inline(cb)
+
+    assert called.get('menu') == (5, 'u', 'N')


### PR DESCRIPTION
## Summary
- ensure the main menu (with change-shop option) is shown when using the home callback
- add regression test for the home callback

## Testing
- `pytest -q` *(fails: pytest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a6d795308333a96a61114127083a