### PR TITLE
Use logging in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,8 +1,12 @@
 import os
+import logging
 from dotenv import load_dotenv
 
 # Cargar variables del archivo .env
 load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Obtener valores de las variables de entorno
 admin_id_env = os.getenv('TELEGRAM_ADMIN_ID')
@@ -37,4 +41,4 @@ if not token:
     print("Asegúrate de que el archivo .env existe y contiene tu token")
     exit(1)
 
-print("✅ Configuración cargada correctamente")
+logger.info('✅ Configuración cargada correctamente')


### PR DESCRIPTION
## Summary
- configure logging in `config.py`
- log success message instead of printing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68716d60dc4c8333a73ca63de4b7b900