### PR TITLE
Adjust /report to notify only super admin

### DIFF
--- a/main.py
+++ b/main.py
@@ -285,12 +285,11 @@ def message_send(message):
                     return
                 username = f"@{message.chat.username}" if message.chat.username else ''
                 notification = f"Reporte de {username} ({message.chat.id}):\n{text}"
-                for admin_id in dop.get_adminlist():
-                    try:
-                        bot.send_message(admin_id, notification)
-                    except Exception as e:
-                        logging.error("Error enviando reporte a %s: %s", admin_id, e)
-                bot.send_message(message.chat.id, '✅ Reporte enviado a los administradores.')
+                try:
+                    bot.send_message(config.admin_id, notification)
+                except Exception as e:
+                    logging.error("Error enviando reporte al super admin %s: %s", config.admin_id, e)
+                bot.send_message(message.chat.id, '✅ Reporte enviado al administrador.')
                 with shelve.open(files.sost_bd) as bd:
                     if str(message.chat.id) in bd:
                         del bd[str(message.chat.id)]

--- a/tests/test_report_command.py
+++ b/tests/test_report_command.py
@@ -47,7 +47,7 @@ def test_report_text_forwarded(monkeypatch, tmp_path):
     with shelve.open(main.files.sost_bd) as bd:
         bd['5'] = 23
 
-    monkeypatch.setattr(dop, 'get_adminlist', lambda: [99])
+    monkeypatch.setattr(main.config, 'admin_id', 99)
 
     menu_called = {}
 


### PR DESCRIPTION
## Summary
- send report notifications directly to `config.admin_id`
- update report tests for the new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687158237954833398a36c3a52c9313e