### PR TITLE
Handle shop selection edits

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,13 +99,28 @@ def send_main_menu(chat_id, username, name):
     else:
         bot.send_message(chat_id, '🏠 Inicio', reply_markup=key)
 
-def show_shop_selection(chat_id):
+def show_shop_selection(chat_id, message=None):
     """Mostrar listado de tiendas disponibles"""
     shops = dop.list_shops()
     key = telebot.types.InlineKeyboardMarkup()
     for sid, _, name in shops:
-        key.add(telebot.types.InlineKeyboardButton(text=name, callback_data=f'SELECT_SHOP_{sid}'))
-    bot.send_message(chat_id, 'Seleccione una tienda:', reply_markup=key)
+        key.add(
+            telebot.types.InlineKeyboardButton(
+                text=name, callback_data=f"SELECT_SHOP_{sid}"
+            )
+        )
+    if message is not None:
+        ok = dop.safe_edit_message(
+            bot, message, "Seleccione una tienda:", reply_markup=key
+        )
+        if not ok:
+            try:
+                bot.delete_message(message.chat.id, message.message_id)
+            except Exception:
+                pass
+            bot.send_message(chat_id, "Seleccione una tienda:", reply_markup=key)
+    else:
+        bot.send_message(chat_id, "Seleccione una tienda:", reply_markup=key)
 
 
 def session_expired(chat_id, username, name):
@@ -541,7 +556,7 @@ def inline(callback):
                                   history, reply_markup=key, parse_mode='Markdown')
         elif callback.data == 'Cambiar tienda':
             bot.answer_callback_query(callback.id)
-            show_shop_selection(callback.message.chat.id)
+            show_shop_selection(callback.message.chat.id, callback.message)
 
 
         elif callback.data == 'Volver al inicio':

--- a/tests/test_change_shop.py
+++ b/tests/test_change_shop.py
@@ -15,12 +15,14 @@ def test_change_shop_callback_invokes_list(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()
 
-    called = {}
+    captured = {}
 
-    def fake_select(cid):
-        called['cid'] = cid
+    def fake_edit(bot, msg, text, reply_markup=None, parse_mode=None):
+        captured['msg'] = msg
+        captured['text'] = text
+        return True
 
-    monkeypatch.setattr(main, 'show_shop_selection', fake_select)
+    monkeypatch.setattr(dop, 'safe_edit_message', fake_edit)
     monkeypatch.setattr(main.bot, 'answer_callback_query', lambda *a, **k: None, raising=False)
 
     class Msg:
@@ -30,10 +32,13 @@ def test_change_shop_callback_invokes_list(monkeypatch, tmp_path):
             self.content_type = 'text'
             self.from_user = types.SimpleNamespace(first_name='a')
 
-    cb = types.SimpleNamespace(data='Cambiar tienda', message=Msg(), id='1', from_user=types.SimpleNamespace(username='u'))
+    cb = types.SimpleNamespace(
+        data='Cambiar tienda', message=Msg(), id='1', from_user=types.SimpleNamespace(username='u')
+    )
     main.inline(cb)
 
-    assert called.get('cid') == 5
+    assert captured.get('msg') is cb.message
+    assert captured.get('text') == 'Seleccione una tienda:'
 
 
 def test_reselect_updates_shop(monkeypatch, tmp_path):

--- a/tests/test_start_welcome.py
+++ b/tests/test_start_welcome.py
@@ -19,8 +19,8 @@ def test_start_existing_user_main_menu(monkeypatch, tmp_path):
     def fake_menu(cid, username, name):
         called["menu"] = (cid, username, name)
 
-    def fake_select(cid):
-        called["select"] = cid
+    def fake_select(cid, message=None):
+        called["select"] = (cid, message)
 
     monkeypatch.setattr(main, "send_main_menu", fake_menu)
     monkeypatch.setattr(main, "show_shop_selection", fake_select)
@@ -54,8 +54,8 @@ def test_start_new_user_shows_shop_list(monkeypatch, tmp_path):
     def fake_menu(cid, username, name):
         called["menu"] = (cid, username, name)
 
-    def fake_select(cid):
-        called["select"] = cid
+    def fake_select(cid, message=None):
+        called["select"] = (cid, message)
 
     monkeypatch.setattr(main, "send_main_menu", fake_menu)
     monkeypatch.setattr(main, "show_shop_selection", fake_select)
@@ -69,7 +69,7 @@ def test_start_new_user_shows_shop_list(monkeypatch, tmp_path):
 
     main.message_send(Msg())
 
-    assert called.get("select") == 5
+    assert called.get("select") == (5, None)
     assert "menu" not in called
 
 
@@ -90,7 +90,7 @@ def test_start_new_user_keeps_showing_list(monkeypatch, tmp_path):
     def fake_menu(cid, username, name):
         called.append(("menu", cid))
 
-    def fake_select(cid):
+    def fake_select(cid, message=None):
         called.append(("select", cid))
 
     monkeypatch.setattr(main, "send_main_menu", fake_menu)


### PR DESCRIPTION
## Summary
- allow `show_shop_selection` to reuse an existing message when provided
- pass callback message to shop-selection routine
- check that message editing is attempted in tests
- adapt tests to optional argument

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68717515d8ec8333914c1d5ed151c392