### PR TITLE
Add product search feature

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -1633,6 +1633,38 @@ def search_user_purchases(search_term, shop_id=1):
         return f"❌ Error buscando compras: {e}"
 
 
+def search_products(keyword, limit=10):
+    """Search products by keyword.
+
+    The function looks for the keyword in both the product name and
+    description using a ``LIKE`` query. It returns a list of tuples with
+    ``(shop_id, shop_name, product_name, price)``.
+
+    Example
+    -------
+    >>> search_products("gift")
+    [(1, "Shop 1", "Gift Card", 5)]
+    """
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        like = f"%{keyword}%"
+        cur.execute(
+            """
+            SELECT g.shop_id, s.name, g.name, g.price
+            FROM goods AS g
+            JOIN shops AS s ON g.shop_id = s.id
+            WHERE g.name LIKE ? OR g.description LIKE ?
+            LIMIT ?
+            """,
+            (like, like, limit),
+        )
+        return cur.fetchall()
+    except Exception as e:
+        logging.error(f"Error searching products: {e}")
+        return []
+
+
 def get_user_purchases(user_id, shop_id=1):
     con = db.get_db_connection()
     cursor = con.cursor()

--- a/main.py
+++ b/main.py
@@ -74,6 +74,8 @@ def send_main_menu(chat_id, username, name):
     key.add(telebot.types.InlineKeyboardButton(text='🛍️ Catálogo', callback_data='Ir al catálogo de productos'))
     key.add(telebot.types.InlineKeyboardButton(
         text='📜 Mis compras', callback_data='Ver mis compras'))
+    key.add(telebot.types.InlineKeyboardButton(
+        text='🔍 Buscar productos', callback_data='Buscar productos'))
     key.add(telebot.types.InlineKeyboardButton(text='Cambiar tienda', callback_data='Cambiar tienda'))
     if dop.check_message('start'):
         with shelve.open(files.bot_message_bd) as bd:
@@ -309,6 +311,22 @@ def message_send(message):
                     if str(message.chat.id) in bd:
                         del bd[str(message.chat.id)]
                 send_main_menu(message.chat.id, message.chat.username, message.from_user.first_name)
+            elif sost_num == 24:
+                term = (message.text or '').strip()
+                results = dop.search_products(term)
+                key = telebot.types.InlineKeyboardMarkup()
+                key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+                if results:
+                    text_lines = ['🔍 **Resultados:**']
+                    for sid, sname, pname, price in results:
+                        text_lines.append(f"🏬 {sname}\n📦 {pname} - ${price} USD\n")
+                    resp = '\n'.join(text_lines)
+                else:
+                    resp = '❌ No se encontraron productos.'
+                bot.send_message(message.chat.id, resp, reply_markup=key, parse_mode='Markdown')
+                with shelve.open(files.sost_bd) as bd:
+                    if str(message.chat.id) in bd:
+                        del bd[str(message.chat.id)]
 
     elif message.chat.id in in_admin:
         adminka.in_adminka(message.chat.id, message.text, message.chat.username, message.from_user.first_name)
@@ -545,6 +563,19 @@ def inline(callback):
             dop.safe_edit_message(bot, callback.message, enhanced_additional, reply_markup=key, parse_mode='Markdown')
             bot.answer_callback_query(callback_query_id=callback.id, show_alert=False, text='ℹ️ Información adicional mostrada')
 
+
+        elif callback.data == 'Buscar productos':
+            key = telebot.types.InlineKeyboardMarkup()
+            key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+            bot.answer_callback_query(callback.id)
+            dop.safe_edit_message(
+                bot,
+                callback.message,
+                '🔍 Escribe palabras clave para buscar productos:',
+                reply_markup=key,
+            )
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(callback.message.chat.id)] = 24
 
         elif callback.data == 'Ver mis compras':
             history = dop.get_user_purchases(callback.message.chat.id)

--- a/tests/test_product_search.py
+++ b/tests/test_product_search.py
@@ -1,0 +1,82 @@
+import types, shelve
+from tests.test_shop_info import setup_main
+from tests.test_categories import setup_dop
+import os
+
+
+def test_search_button_in_menu(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    main.send_main_menu(5, 'u', 'N')
+    buttons = calls[-1][2]['reply_markup'].buttons
+    assert any('Buscar productos' in b.text for b in buttons)
+
+
+def test_search_products_query(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid1 = dop.create_shop('S1', admin_id=1)
+    sid2 = dop.create_shop('S2', admin_id=1)
+    dop.create_product('Widget', 'great tool', 'txt', 1, 10, 'x', shop_id=sid1)
+    dop.create_product('Gadget', 'useful item', 'txt', 1, 20, 'y', shop_id=sid2)
+
+    res1 = dop.search_products('wid')
+    assert any(r[2] == 'Widget' for r in res1)
+    res2 = dop.search_products('useful')
+    assert any(r[2] == 'Gadget' for r in res2)
+
+
+def test_inline_sets_search_state(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    os.makedirs('data/bd', exist_ok=True)
+    monkeypatch.setattr(main.files, 'sost_bd', str(tmp_path / 'sost.bd'))
+
+    captured = {}
+
+    def fake_edit(bot, msg, text, reply_markup=None, parse_mode=None):
+        captured['text'] = text
+        return True
+
+    monkeypatch.setattr(dop, 'safe_edit_message', fake_edit)
+    monkeypatch.setattr(main.bot, 'answer_callback_query', lambda *a, **k: None, raising=False)
+
+    class Msg:
+        def __init__(self):
+            self.chat = types.SimpleNamespace(id=5, username='u')
+            self.message_id = 1
+            self.content_type = 'text'
+            self.from_user = types.SimpleNamespace(first_name='N')
+
+    cb = types.SimpleNamespace(data='Buscar productos', message=Msg(), id='1', from_user=types.SimpleNamespace(username='u'))
+    main.inline(cb)
+
+    with shelve.open(main.files.sost_bd) as bd:
+        assert bd[str(cb.message.chat.id)] == 24
+    assert 'buscar productos' in captured['text'].lower()
+
+
+def test_message_search_results(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    monkeypatch.setattr(main.files, 'sost_bd', str(tmp_path / 'sost.bd'))
+    with shelve.open(main.files.sost_bd) as bd:
+        bd['5'] = 24
+
+    def fake_search(term, limit=10):
+        return [(1, 'S1', 'Widget', 10)]
+
+    monkeypatch.setattr(dop, 'search_products', fake_search)
+
+    class Msg:
+        def __init__(self, text):
+            self.text = text
+            self.chat = types.SimpleNamespace(id=5, username='u')
+            self.from_user = types.SimpleNamespace(first_name='N')
+            self.content_type = 'text'
+
+    main.message_send(Msg('wid'))
+
+    with shelve.open(main.files.sost_bd) as bd:
+        assert '5' not in bd
+    assert any('Widget' in c[1][1] for c in calls if c[0] == 'send_message')


### PR DESCRIPTION
## Summary
- add search_products helper with documentation
- extend main menu with 'Buscar productos'
- prompt for product search in inline callbacks
- search products when state 24 is active
- test product search flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ae6330d0833388275d38a4900bcf