### PR TITLE
Add product campaign deep link feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Desde el panel de administración aparecerá una nueva opción **📢 Marketing*
 con comandos para gestionar campañas:
 
 - `🎯 Nueva campaña` para registrar una campaña.
+- `🛒 Campaña de producto` para crear una campaña basada en un producto existente.
 - `📋 Ver campañas` para listar las existentes.
 - `🗑️ Eliminar campaña` para borrar una campaña indicando su ID.
 - `⏰ Programar envíos` para definir los horarios.
@@ -204,6 +205,11 @@ con comandos para gestionar campañas:
 - `▶️ Envío manual <ID>` para disparar un envío inmediato indicando el
   identificador de la campaña. Tras introducir el ID el bot mostrará una lista
   de grupos objetivo para seleccionar.
+
+La *Campaña de producto* permite seleccionar uno de los artículos ya creados y
+enviar su información como anuncio. El bot añadirá automáticamente un botón que
+apunta al producto usando un enlace profundo, de modo que al abrirlo se muestren
+los detalles de ese artículo.
 
 Durante estos flujos puedes cancelar en cualquier momento enviando `Cancelar` o
 `/cancel`, o presionando el botón *Cancelar y volver a Marketing* para regresar

--- a/adminka.py
+++ b/adminka.py
@@ -78,6 +78,7 @@ def show_marketing_menu(chat_id):
     """Mostrar menú principal de marketing"""
     user_markup = telebot.types.ReplyKeyboardMarkup(True, False)
     user_markup.row('🎯 Nueva campaña', '📋 Ver campañas')
+    user_markup.row('🛒 Campaña de producto')
     user_markup.row('🗑️ Eliminar campaña')
     user_markup.row('⏰ Programar envíos', '🎯 Gestionar grupos')
     user_markup.row('📊 Estadísticas hoy', '⚙️ Configuración')
@@ -94,6 +95,56 @@ def show_marketing_menu(chat_id):
     )
 
     bot.send_message(chat_id, stats_text, reply_markup=user_markup, parse_mode='Markdown')
+
+
+def finalize_product_campaign(chat_id, shop_id):
+    """Crear campaña de producto con enlace automático."""
+    try:
+        with open(f'data/Temp/{chat_id}campaign_name.txt', encoding='utf-8') as f:
+            name = f.read()
+        with open(f'data/Temp/{chat_id}_campaign_product.txt', encoding='utf-8') as f:
+            product = f.read()
+        with open(f'data/Temp/{chat_id}campaign_message.txt', encoding='utf-8') as f:
+            text = f.read()
+        media_file_id = None
+        media_type = None
+        media_path = f'data/Temp/{chat_id}_campaign_media.txt'
+        if os.path.exists(media_path):
+            with open(media_path, 'r', encoding='utf-8') as mf:
+                lines = mf.read().splitlines()
+                if len(lines) >= 2:
+                    media_file_id = lines[0]
+                    media_type = lines[1]
+    except FileNotFoundError:
+        session_expired(chat_id)
+        return
+
+    data = {
+        'name': name,
+        'message_text': text,
+        'media_file_id': media_file_id,
+        'media_type': media_type,
+        'button1_text': 'Ver producto',
+        'button1_url': dop.get_product_link(product, shop_id),
+        'created_by': chat_id,
+    }
+    ok, msg = create_campaign_from_admin(data)
+    bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
+    with shelve.open(files.sost_bd) as bd:
+        if str(chat_id) in bd:
+            del bd[str(chat_id)]
+    for p in [
+        f'data/Temp/{chat_id}campaign_name.txt',
+        f'data/Temp/{chat_id}campaign_message.txt',
+        f'data/Temp/{chat_id}_campaign_media.txt',
+        f'data/Temp/{chat_id}_campaign_product.txt',
+    ]:
+        try:
+            if os.path.exists(p):
+                os.remove(p)
+        except Exception:
+            pass
+    show_marketing_menu(chat_id)
 
 
 
@@ -568,6 +619,19 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, '📝 *Nombre de la campaña*\n\nEnvía el nombre para la nueva campaña:', reply_markup=key, parse_mode='Markdown')
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 160
+
+        elif '🛒 Campaña de producto' == message_text:
+            goods = dop.get_goods(shop_id)
+            if not goods:
+                bot.send_message(chat_id, 'No hay productos disponibles.')
+            else:
+                markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                for g in goods:
+                    markup.row(g)
+                markup.row('Cancelar')
+                bot.send_message(chat_id, 'Seleccione el producto para la campaña:', reply_markup=markup)
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 190
 
         elif '📋 Ver campañas' == message_text:
             campaigns = advertising.get_all_campaigns()
@@ -2135,6 +2199,43 @@ def text_analytics(message_text, chat_id):
             except Exception:
                 pass
 
+        elif sost_num == 190:  # Selección de producto
+            if message_text == 'Cancelar':
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                show_marketing_menu(chat_id)
+            else:
+                goods = dop.get_goods(shop_id)
+                if message_text not in goods:
+                    bot.send_message(chat_id, 'Selección inválida. Intente nuevamente.')
+                    return
+                os.makedirs('data/Temp', exist_ok=True)
+                with open(f'data/Temp/{chat_id}_campaign_product.txt', 'w', encoding='utf-8') as f:
+                    f.write(message_text)
+                with open(f'data/Temp/{chat_id}campaign_name.txt', 'w', encoding='utf-8') as f:
+                    f.write(f'Producto {message_text}')
+                key = telebot.types.InlineKeyboardMarkup()
+                key.add(telebot.types.InlineKeyboardButton(text='Cancelar y volver a Marketing', callback_data='Volver a Marketing'))
+                bot.send_message(chat_id, '📝 **Mensaje de la campaña**\n\nEscribe el texto que se enviará (máximo 500 caracteres):', reply_markup=key, parse_mode='Markdown')
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 191
+
+        elif sost_num == 191:  # Texto campaña de producto
+            if len(message_text) > 500:
+                bot.send_message(chat_id, '❌ El mensaje es muy largo. Máximo 500 caracteres.')
+                return
+            with open(f'data/Temp/{chat_id}campaign_message.txt', 'w', encoding='utf-8') as f:
+                f.write(message_text)
+            bot.send_message(chat_id, 'Si deseas adjuntar una foto, video o documento envíalo ahora o escribe "no" para omitir:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 192
+
+        elif sost_num == 192:  # Multimedia opcional producto
+            if message_text.lower() in ('no', 'sin archivo'):
+                finalize_product_campaign(chat_id, shop_id)
+            else:
+                bot.send_message(chat_id, '❌ Envía la foto, video o documento o escribe "no" para continuar sin archivo.')
+
         elif sost_num == 165:  # Guardar texto o multimedia editada
             path = f'data/Temp/{chat_id}_edit_campaign.txt'
             data_path = f'data/Temp/{chat_id}_edit_campaign_data.json'
@@ -2550,6 +2651,9 @@ def handle_multimedia(message):
         elif state == 162:
             temp_path = None
             media_path = f'data/Temp/{chat_id}_campaign_media.txt'
+        elif state == 192:
+            temp_path = None
+            media_path = f'data/Temp/{chat_id}_campaign_media.txt'
         elif state == 165:
             temp_path = None
         elif state == 305:
@@ -2630,6 +2734,12 @@ def handle_multimedia(message):
                 bot.send_message(chat_id, 'Si deseas agregar un botón escribe:\n<texto> <url>\nEscribe "no" para continuar sin botones:')
                 with shelve.open(files.sost_bd) as bd:
                     bd[str(chat_id)] = 163
+                return
+            elif state == 192:
+                with open(media_path, 'w', encoding='utf-8') as f:
+                    f.write(file_id + '\n')
+                    f.write(media_type)
+                finalize_product_campaign(chat_id, shop_id)
                 return
             elif state == 165:
                 path = f'data/Temp/{chat_id}_edit_campaign.txt'

--- a/dop.py
+++ b/dop.py
@@ -1,4 +1,4 @@
-import telebot, shelve, datetime, sqlite3, random, os
+import telebot, shelve, datetime, sqlite3, random, os, re
 import files, config
 import db
 from bot_instance import bot
@@ -8,6 +8,30 @@ logging.basicConfig(level=logging.INFO)
 
 # Flag to avoid repeated logging when initializing discounts
 _discount_initialized = False
+
+
+def _slugify(name):
+    """Convert product name to URL-friendly slug."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", name).lower().strip("-")
+    return slug
+
+
+def get_product_link(product_name, shop_id):
+    """Generate a deep-link URL for a product."""
+    try:
+        username = bot.get_me().username
+    except Exception:
+        username = ""
+    slug = _slugify(product_name)
+    return f"https://t.me/{username}?start=prod_{shop_id}_{slug}"
+
+
+def get_product_by_slug(slug, shop_id=1):
+    """Return product name matching the slug for the given shop."""
+    for name in get_goods(shop_id):
+        if _slugify(name) == slug:
+            return name
+    return None
 
 # ---------------------------------------------------------------------------
 # Utilidad para asegurar que la base de datos tenga las columnas necesarias

--- a/main.py
+++ b/main.py
@@ -125,6 +125,35 @@ def show_shop_selection(chat_id, message=None):
         bot.send_message(chat_id, "Seleccione una tienda:", reply_markup=key)
 
 
+def show_product_details(chat_id, product_name, shop_id):
+    """Mostrar información de un producto como en el catálogo."""
+    os.makedirs('data/Temp', exist_ok=True)
+    with open(f'data/Temp/{chat_id}good_name.txt', 'w', encoding='utf-8') as f:
+        f.write(product_name)
+    key = telebot.types.InlineKeyboardMarkup()
+    if dop.has_additional_description(product_name, shop_id):
+        key.add(telebot.types.InlineKeyboardButton(text='ℹ️ Más información', callback_data=f'MAS_INFO_{product_name}'))
+    key.add(telebot.types.InlineKeyboardButton(text='💰 Comprar ahora', callback_data='Comprar'))
+    key.add(telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio'))
+    media_info = dop.get_product_media(product_name, shop_id)
+    formatted_info = dop.format_product_with_media(product_name, shop_id)
+    if media_info:
+        if media_info['type'] == 'photo':
+            bot.send_photo(chat_id, media_info['file_id'], caption=formatted_info, reply_markup=key, parse_mode='Markdown')
+        elif media_info['type'] == 'video':
+            bot.send_video(chat_id, media_info['file_id'], caption=formatted_info, reply_markup=key, parse_mode='Markdown')
+        elif media_info['type'] == 'document':
+            bot.send_document(chat_id, media_info['file_id'], caption=formatted_info, reply_markup=key, parse_mode='Markdown')
+        elif media_info['type'] == 'audio':
+            bot.send_audio(chat_id, media_info['file_id'], caption=formatted_info, reply_markup=key, parse_mode='Markdown')
+        elif media_info['type'] == 'animation':
+            bot.send_animation(chat_id, media_info['file_id'], caption=formatted_info, reply_markup=key, parse_mode='Markdown')
+        else:
+            bot.send_message(chat_id, formatted_info, reply_markup=key, parse_mode='Markdown')
+    else:
+        bot.send_message(chat_id, formatted_info, reply_markup=key, parse_mode='Markdown')
+
+
 def session_expired(chat_id, username, name):
     """Informar expiración de sesión y volver al menú principal"""
     bot.send_message(chat_id, '❌ La sesión expiró.')
@@ -152,11 +181,29 @@ def message_send(message):
         stripped = message.text.strip()
         if stripped:
             first_word = stripped.split()[0].lower()
-    if '/start' == message.text:
+    if message.text and message.text.startswith('/start'):
+        param = message.text.split(maxsplit=1)
+        start_param = param[1] if len(param) > 1 else ''
+        if start_param.startswith('prod_'):
+            parts = start_param.split('_', 2)
+            product = None
+            if len(parts) == 3:
+                try:
+                    shop_id = int(parts[1])
+                except ValueError:
+                    shop_id = None
+                if shop_id is not None:
+                    slug = parts[2]
+                    product = dop.get_product_by_slug(slug, shop_id)
+                    dop.set_user_shop(message.chat.id, shop_id)
+            if product:
+                show_product_details(message.chat.id, product, shop_id)
+                dop.user_loger(chat_id=message.chat.id)
+                return
         if message.chat.username:
             # Limpiar estado si existe
-            if dop.get_sost(message.chat.id) is True: 
-                with shelve.open(files.sost_bd) as bd: 
+            if dop.get_sost(message.chat.id) is True:
+                with shelve.open(files.sost_bd) as bd:
                     if str(message.chat.id) in bd:
                         del bd[str(message.chat.id)]
             

--- a/tests/test_product_campaign.py
+++ b/tests/test_product_campaign.py
@@ -1,0 +1,74 @@
+import types, os, re
+from tests.test_shop_info import setup_main
+
+
+def slug(name):
+    return re.sub(r"[^a-zA-Z0-9]+", "-", name).lower().strip("-")
+
+
+def test_product_campaign_creates_button(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.create_product("Item", "d", "txt", 1, 2, "x", shop_id=sid)
+
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(main.adminka.dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(main.adminka.files, "sost_bd", str(tmp_path / "sost.bd"))
+    keyboard_stub = lambda *a, **k: types.SimpleNamespace(row=lambda *b, **c: None)
+    monkeypatch.setattr(main.adminka.telebot.types, "ReplyKeyboardMarkup", keyboard_stub, raising=False)
+    monkeypatch.setattr(main.adminka.advertising, "get_today_stats", lambda: {"sent": 0, "success_rate": 100, "groups": 0})
+    created = {}
+
+    def fake_create(data):
+        created.update(data)
+        return True, "ok"
+
+    monkeypatch.setattr(main.adminka, "create_campaign_from_admin", fake_create)
+
+    os.makedirs("data/Temp", exist_ok=True)
+    # Preparar archivos como los que crea el flujo
+    with open("data/Temp/1_campaign_product.txt", "w", encoding="utf-8") as f:
+        f.write("Item")
+    with open("data/Temp/1campaign_name.txt", "w", encoding="utf-8") as f:
+        f.write("Producto Item")
+    with open("data/Temp/1campaign_message.txt", "w", encoding="utf-8") as f:
+        f.write("Promo")
+
+    main.adminka.finalize_product_campaign(1, sid)
+
+    assert created["name"] == "Producto Item"
+    assert created["message_text"] == "Promo"
+    assert created["button1_text"] == "Ver producto"
+    assert created["button1_url"].endswith(f"prod_{sid}_" + slug("Item"))
+
+
+def test_start_param_shows_product(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    dop.create_product("Item2", "d", "txt", 1, 2, "x", shop_id=sid)
+
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [1])
+    monkeypatch.setattr(dop, "get_sost", lambda cid: False)
+    monkeypatch.setattr(dop, "user_loger", lambda chat_id=0: None)
+
+    param = f"prod_{sid}_" + slug("Item2")
+
+    class Msg:
+        def __init__(self):
+            self.text = f"/start {param}"
+            self.chat = types.SimpleNamespace(id=5, username="u")
+            self.from_user = types.SimpleNamespace(first_name="N")
+            self.content_type = "text"
+
+    main.message_send(Msg())
+
+    assert dop.get_user_shop(5) == sid
+    texts = []
+    for c in calls:
+        if c[0] == "send_message":
+            texts.append(c[1][1])
+        elif c[0] in ("send_photo", "send_video", "send_document", "send_audio", "send_animation"):
+            texts.append(c[2].get("caption", ""))
+    assert any("Item2" in t for t in texts)


### PR DESCRIPTION
## Summary
- include '🛒 Campaña de producto' option in marketing menu
- allow creating campaigns linked to a product
- add deep-link helpers for products
- support `/start prod_<shop>_<slug>` parameters
- document product campaigns
- test product campaign creation and deep-link start

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871cbd4eab88333bb7603dc9a95a20f