### PR TITLE
Add campaign limit configuration

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -831,6 +831,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('Cambiar descripción de tienda')
             user_markup.row('Cambiar multimedia de tienda')
             user_markup.row('Cambiar botones de tienda')
+            user_markup.row('Configurar límite de campañas')
             if chat_id == config.admin_id:
                 user_markup.row('Cambiar mensaje de inicio (/start)')
             if chat_id == config.admin_id:
@@ -885,6 +886,21 @@ def in_adminka(chat_id, message_text, username, name_user):
             bot.send_message(chat_id, 'Texto para el primer botón (o "ninguno"):')
             with shelve.open(files.sost_bd) as bd:
                 bd[str(chat_id)] = 306
+
+        elif message_text == 'Configurar límite de campañas':
+            if chat_id == config.admin_id:
+                bot.send_message(chat_id, 'Ingrese el ID de la tienda a configurar:')
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 310
+            else:
+                shop_id = dop.get_shop_id(chat_id)
+                limit = dop.get_campaign_limit(shop_id)
+                bot.send_message(
+                    chat_id,
+                    f'Límite actual: {limit}\nIngresa el nuevo límite de campañas:',
+                )
+                with shelve.open(files.sost_bd) as bd:
+                    bd[str(chat_id)] = 311
 
         elif message_text == 'Cambiar mensaje de inicio (/start)' and chat_id == config.admin_id:
             bot.send_message(chat_id,
@@ -1813,6 +1829,48 @@ def text_analytics(message_text, chat_id):
             with shelve.open(files.sost_bd) as bd:
                 del bd[str(chat_id)]
             os.remove(path)
+
+        elif sost_num == 310 and chat_id == config.admin_id:
+            try:
+                shop_id_target = int(message_text)
+            except ValueError:
+                bot.send_message(chat_id, '❌ ID inválido. Ingrese un número de tienda.')
+                return
+            limit = dop.get_campaign_limit(shop_id_target)
+            with open(f'data/Temp/{chat_id}_camp_limit_shop.txt', 'w', encoding='utf-8') as f:
+                f.write(str(shop_id_target))
+            bot.send_message(chat_id, f'Límite actual: {limit}\nIngresa el nuevo límite de campañas:')
+            with shelve.open(files.sost_bd) as bd:
+                bd[str(chat_id)] = 311
+
+        elif sost_num == 311:
+            try:
+                new_limit = int(message_text)
+                if new_limit < 0:
+                    raise ValueError
+            except ValueError:
+                bot.send_message(chat_id, '❌ Por favor ingrese un número válido.')
+                return
+            if chat_id == config.admin_id:
+                try:
+                    with open(f'data/Temp/{chat_id}_camp_limit_shop.txt', 'r', encoding='utf-8') as f:
+                        shop_id_target = int(f.read().strip())
+                except Exception:
+                    shop_id_target = dop.get_shop_id(chat_id)
+            else:
+                shop_id_target = dop.get_shop_id(chat_id)
+            if dop.set_campaign_limit(new_limit, shop_id=shop_id_target):
+                bot.send_message(chat_id, '✅ Límite actualizado.')
+            else:
+                bot.send_message(chat_id, '❌ Error actualizando límite.')
+            with shelve.open(files.sost_bd) as bd:
+                del bd[str(chat_id)]
+            if chat_id == config.admin_id:
+                try:
+                    os.remove(f'data/Temp/{chat_id}_camp_limit_shop.txt')
+                except Exception:
+                    pass
+            in_adminka(chat_id, '⚙️ Otros', None, None)
 
         elif sost_num == 500:
             text_path = f'data/Temp/{chat_id}_start_text.txt'

--- a/dop.py
+++ b/dop.py
@@ -59,7 +59,8 @@ def ensure_database_schema():
                 button1_text TEXT,
                 button1_url TEXT,
                 button2_text TEXT,
-                button2_url TEXT
+                button2_url TEXT,
+                campaign_limit INTEGER DEFAULT 3
             )
             """
         )
@@ -80,6 +81,8 @@ def ensure_database_schema():
             cursor.execute("ALTER TABLE shops ADD COLUMN button2_text TEXT")
         if 'button2_url' not in shop_cols:
             cursor.execute("ALTER TABLE shops ADD COLUMN button2_url TEXT")
+        if 'campaign_limit' not in shop_cols:
+            cursor.execute("ALTER TABLE shops ADD COLUMN campaign_limit INTEGER DEFAULT 3")
 
         cursor.execute(
             "CREATE TABLE IF NOT EXISTS categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE NOT NULL, shop_id INTEGER)"
@@ -1016,10 +1019,18 @@ def get_shop_id(admin_id):
         row = cur.fetchone()
         if row:
             return row[0]
-        cur.execute(
-            "INSERT INTO shops (admin_id, name) VALUES (?, ?)",
-            (admin_id, f'Shop {admin_id}')
-        )
+        cur.execute("PRAGMA table_info(shops)")
+        cols = [c[1] for c in cur.fetchall()]
+        if 'campaign_limit' in cols:
+            cur.execute(
+                "INSERT INTO shops (admin_id, name, campaign_limit) VALUES (?, ?, 3)",
+                (admin_id, f'Shop {admin_id}')
+            )
+        else:
+            cur.execute(
+                "INSERT INTO shops (admin_id, name) VALUES (?, ?)",
+                (admin_id, f'Shop {admin_id}')
+            )
         con.commit()
         return cur.lastrowid
     except Exception as e:
@@ -1037,15 +1048,23 @@ def list_shops():
         logging.error(f"Error listando tiendas: {e}")
         return []
 
-def create_shop(name, admin_id=None):
+def create_shop(name, admin_id=None, campaign_limit=3):
     """Crear una nueva tienda y devolver su ID."""
     try:
         con = db.get_db_connection()
         cur = con.cursor()
-        cur.execute(
-            "INSERT INTO shops (admin_id, name) VALUES (?, ?)",
-            (admin_id, name)
-        )
+        cur.execute("PRAGMA table_info(shops)")
+        cols = [c[1] for c in cur.fetchall()]
+        if 'campaign_limit' in cols:
+            cur.execute(
+                "INSERT INTO shops (admin_id, name, campaign_limit) VALUES (?, ?, ?)",
+                (admin_id, name, campaign_limit),
+            )
+        else:
+            cur.execute(
+                "INSERT INTO shops (admin_id, name) VALUES (?, ?)",
+                (admin_id, name),
+            )
         con.commit()
         return cur.lastrowid
     except Exception as e:
@@ -1149,6 +1168,33 @@ def get_shop_info(shop_id):
     except Exception as e:
         logging.error(f"Error obteniendo información de tienda: {e}")
         return None
+
+def get_campaign_limit(shop_id=1):
+    """Obtener el límite de campañas para una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute("SELECT campaign_limit FROM shops WHERE id = ?", (shop_id,))
+        row = cur.fetchone()
+        return int(row[0]) if row and row[0] is not None else 3
+    except Exception as e:
+        logging.error(f"Error obteniendo campaign_limit: {e}")
+        return 3
+
+def set_campaign_limit(limit, shop_id=1):
+    """Actualizar el límite de campañas de una tienda."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            "UPDATE shops SET campaign_limit = ? WHERE id = ?",
+            (int(limit), shop_id),
+        )
+        con.commit()
+        return cur.rowcount > 0
+    except Exception as e:
+        logging.error(f"Error estableciendo campaign_limit: {e}")
+        return False
 
 # ------------------------------------------------------------------
 # Funciones para la tienda seleccionada por cada usuario

--- a/init_db.py
+++ b/init_db.py
@@ -38,7 +38,8 @@ def create_database():
             button1_text TEXT,
             button1_url TEXT,
             button2_text TEXT,
-            button2_url TEXT
+            button2_url TEXT,
+            campaign_limit INTEGER DEFAULT 3
         )
     ''')
     print("✓ Tabla 'shops' creada")


### PR DESCRIPTION
## Summary
- add `campaign_limit` column and helper functions
- allow editing campaign limit in admin menu
- extend database schema for new column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d6446c1c8333b18a3c8af5777b53