### PR TITLE
Fix autosender when target platforms missing

### DIFF
--- a/advertising_system/auto_sender.py
+++ b/advertising_system/auto_sender.py
@@ -74,6 +74,8 @@ class AutoSender:
         for send_data in pending_sends:
             schedule_id = send_data[0]
             campaign_id = send_data[1]
+            if not send_data[5]:
+                continue
             platforms = send_data[5].split(',')
             for platform in platforms:
                 if platform == 'telegram':

--- a/test_exact_time.py
+++ b/test_exact_time.py
@@ -2,50 +2,54 @@ import sqlite3
 import json
 from datetime import datetime, timedelta
 
-# Simular exactamente las 00:40 (cuando se ejecutó el cron)
-test_time = datetime(2025, 7, 12, 0, 40, 8)
-day_map = ['lunes', 'martes', 'miercoles', 'jueves', 'viernes', 'sabado', 'domingo']
-today = day_map[test_time.weekday()]
 
-# Rango que habría usado el sistema a las 00:40:08
-time_range = []
-for offset in [-2, -1, 0, 1, 2]:
-    time_check = (test_time + timedelta(minutes=offset)).strftime('%H:%M')
-    time_range.append(time_check)
+if __name__ == "__main__":
+    # Simular exactamente las 00:40 (cuando se ejecutó el cron)
+    test_time = datetime(2025, 7, 12, 0, 40, 8)
+    day_map = ['lunes', 'martes', 'miercoles', 'jueves', 'viernes', 'sabado', 'domingo']
+    today = day_map[test_time.weekday()]
 
-print(f"Simulando: {test_time}")
-print(f"Día: {today}")
-print(f"Rango que buscó: {time_range}")
+    # Rango que habría usado el sistema a las 00:40:08
+    time_range = []
+    for offset in [-2, -1, 0, 1, 2]:
+        time_check = (test_time + timedelta(minutes=offset)).strftime('%H:%M')
+        time_range.append(time_check)
 
-# Buscar la programación específica para 00:39
-conn = sqlite3.connect('data/db/main_data.db')
-cursor = conn.cursor()
-cursor.execute("""
-    SELECT cs.schedule_json, c.name
-    FROM campaign_schedules cs
-    JOIN campaigns c ON cs.campaign_id = c.id
-    WHERE cs.is_active = 1 AND c.status = 'active'
-    AND cs.schedule_json LIKE '%00:39%'
-""")
+    print(f"Simulando: {test_time}")
+    print(f"Día: {today}")
+    print(f"Rango que buscó: {time_range}")
 
-for row in cursor.fetchall():
-    schedule = json.loads(row[0])
-    scheduled_times = schedule.get(today, [])
-    
-    print(f"\nCampaña: {row[1]}")
-    print(f"Programada para: {scheduled_times}")
-    
-    if any(t in scheduled_times for t in time_range):
-        print("✅ DEBERÍA HABER FUNCIONADO!")
-    else:
-        print("❌ No funcionó")
-        print(f"Buscaba: {time_range}")
-        print(f"En: {scheduled_times}")
-        
-        # Verificar si 00:39 está en el rango
-        if '00:39' in time_range:
-            print("🔍 '00:39' SÍ está en el rango - HAY UN BUG")
+    # Buscar la programación específica para 00:39
+    conn = sqlite3.connect('data/db/main_data.db')
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT cs.schedule_json, c.name
+        FROM campaign_schedules cs
+        JOIN campaigns c ON cs.campaign_id = c.id
+        WHERE cs.is_active = 1 AND c.status = 'active'
+        AND cs.schedule_json LIKE '%00:39%'
+        """
+    )
+
+    for row in cursor.fetchall():
+        schedule = json.loads(row[0])
+        scheduled_times = schedule.get(today, [])
+
+        print(f"\nCampaña: {row[1]}")
+        print(f"Programada para: {scheduled_times}")
+
+        if any(t in scheduled_times for t in time_range):
+            print("✅ DEBERÍA HABER FUNCIONADO!")
         else:
-            print("🔍 '00:39' NO está en el rango - problema de timing")
+            print("❌ No funcionó")
+            print(f"Buscaba: {time_range}")
+            print(f"En: {scheduled_times}")
 
-conn.close()
+            # Verificar si 00:39 está en el rango
+            if '00:39' in time_range:
+                print("🔍 '00:39' SÍ está en el rango - HAY UN BUG")
+            else:
+                print("🔍 '00:39' NO está en el rango - problema de timing")
+
+    conn.close()

--- a/tests/test_auto_sender.py
+++ b/tests/test_auto_sender.py
@@ -30,6 +30,26 @@ def test_check_and_send_campaigns_returns_bool(tmp_path, monkeypatch):
     assert calls == []
 
 
+def test_check_and_send_campaigns_none_platforms(tmp_path, monkeypatch):
+    sys.modules.pop('advertising_system.auto_sender', None)
+    auto_sender = importlib.import_module('advertising_system.auto_sender')
+    AutoSender = auto_sender.AutoSender
+
+    config = {
+        'db_path': str(tmp_path / 'db.db'),
+        'telegram_tokens': ['t']
+    }
+    sender = AutoSender(config)
+
+    monkeypatch.setattr(auto_sender.time, 'sleep', lambda x: None)
+    calls = []
+    monkeypatch.setattr(sender, '_send_telegram_campaign', lambda *a, **k: calls.append('tg'))
+
+    sender.scheduler.get_pending_sends = lambda: [(1, 2, None, None, None, None)]
+    assert sender._check_and_send_campaigns() is False
+    assert calls == []
+
+
 def test_check_and_send_campaigns_with_mocked_dependencies(monkeypatch):
     sys.modules.pop('advertising_system.auto_sender', None)
     auto_sender = importlib.import_module('advertising_system.auto_sender')


### PR DESCRIPTION
## Summary
- skip campaigns missing platform data
- add regression test for missing platforms
- guard standalone debug script so tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d050a0348333b216f4d0861f81c4