### PR TITLE
Add buyer summary option

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -185,6 +185,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             user_markup.row('📦 Surtido', '➕ Producto')
             user_markup.row('💰 Pagos')
             user_markup.row('📊 Stats', '📣 Difusión')
+            user_markup.row('Resumen de compradores')
             user_markup.row('📢 Marketing')
             user_markup.row('🏷️ Categorías')
             user_markup.row('💸 Descuentos')
@@ -540,6 +541,16 @@ def in_adminka(chat_id, message_text, username, name_user):
         elif '📊 Stats' == message_text:
             result = dop.get_daily_sales()
             bot.send_message(chat_id, result, parse_mode='Markdown')
+
+        elif 'Resumen de compradores' == message_text:
+            lines = dop.get_buyers_summary(shop_id)
+            if not lines:
+                bot.send_message(chat_id, 'No hay compras registradas.')
+            else:
+                step = 10
+                for i in range(0, len(lines), step):
+                    part = '\n'.join(lines[i:i + step])
+                    bot.send_message(chat_id, part)
 
         elif '📣 Difusión' == message_text:
             user_markup = telebot.types.ReplyKeyboardMarkup(True, False)

--- a/dop.py
+++ b/dop.py
@@ -1760,6 +1760,36 @@ def get_user_purchases(user_id, shop_id=1):
     return response
 
 
+def get_buyers_summary(shop_id=1):
+    """Return purchase summary grouped by buyer."""
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        cur.execute(
+            """
+            SELECT id, MAX(username), SUM(price),
+                   GROUP_CONCAT(DISTINCT name_good)
+            FROM purchases
+            WHERE shop_id = ?
+            GROUP BY id
+            ORDER BY SUM(price) DESC
+            """,
+            (shop_id,)
+        )
+        rows = cur.fetchall()
+        lines = []
+        for idx, (uid, uname, total, products) in enumerate(rows, 1):
+            uname = uname or ''
+            prod_list = products or ''
+            lines.append(
+                f"{idx}. {uid} (@{uname}) - ${total} USD - {prod_list}"
+            )
+        return lines
+    except Exception as e:
+        logging.error(f"Error obteniendo resumen de compradores: {e}")
+        return []
+
+
 def get_discount_config(shop_id=1):
     """Obtiene la configuración de descuentos para una tienda"""
     setup_discount_system()

--- a/tests/test_buyer_summary.py
+++ b/tests/test_buyer_summary.py
@@ -1,0 +1,28 @@
+import sqlite3
+from tests.test_categories import setup_dop
+
+
+def test_get_buyers_summary(monkeypatch, tmp_path):
+    monkeypatch.setenv("WEBHOOK_URL", "https://example.com/bot")
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO purchases (id, username, name_good, amount, price, shop_id) VALUES (1,'u1','P1',1,5,1)"
+    )
+    cur.execute(
+        "INSERT INTO purchases (id, username, name_good, amount, price, shop_id) VALUES (1,'u1','P2',1,10,1)"
+    )
+    cur.execute(
+        "INSERT INTO purchases (id, username, name_good, amount, price, shop_id) VALUES (2,'u2','P2',1,20,1)"
+    )
+    conn.commit()
+    conn.close()
+
+    lines = dop.get_buyers_summary(1)
+    assert len(lines) == 2
+    line_u1 = next((l for l in lines if 'u1' in l), '')
+    assert '15' in line_u1
+    assert 'P1' in line_u1 and 'P2' in line_u1


### PR DESCRIPTION
## Summary
- add `get_buyers_summary` in `dop.py` to aggregate purchases by buyer
- extend admin menu with "Resumen de compradores" option
- show buyer summary with simple pagination
- add unit test for new function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac4e9edb48333afb5373cbdd88170