### PR TITLE
Add purchase expiration notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,21 @@ al menú de marketing.
 necesitas repartir la carga entre diferentes bots.  Si la variable no está
 definida el script terminará con un error.
 
+## Expiración de compras
+
+Si defines la opción **duración en días** para un producto, las compras de ese
+artículo almacenarán su fecha de vencimiento. Para avisar a los usuarios cuando
+una compra haya expirado ejecuta periódicamente `expiration_cron.py` (por
+ejemplo con `cron` o como servicio). El script buscará compras vencidas y
+enviará un mensaje al comprador sugiriendo renovar la adquisición.
+
+```bash
+python expiration_cron.py
+```
+
+Al igual que el módulo de marketing, este script utiliza el token configurado en
+`config.py` a través de `bot_instance.py` para enviar las notificaciones.
+
 ## Pruebas
 
 Para ejecutar las pruebas automatizadas instala las dependencias y luego ejecuta:

--- a/dop.py
+++ b/dop.py
@@ -192,6 +192,9 @@ def ensure_database_schema():
                 name_good TEXT,
                 amount INTEGER,
                 price INTEGER,
+                payment_method TEXT,
+                timestamp TEXT,
+                expires_at TEXT,
                 shop_id INTEGER DEFAULT 1
             )
             """
@@ -199,6 +202,15 @@ def ensure_database_schema():
 
         cursor.execute("PRAGMA table_info(purchases)")
         purch_cols = [c[1] for c in cursor.fetchall()]
+        if 'payment_method' not in purch_cols:
+            cursor.execute("ALTER TABLE purchases ADD COLUMN payment_method TEXT")
+            updated = True
+        if 'timestamp' not in purch_cols:
+            cursor.execute("ALTER TABLE purchases ADD COLUMN timestamp TEXT")
+            updated = True
+        if 'expires_at' not in purch_cols:
+            cursor.execute("ALTER TABLE purchases ADD COLUMN expires_at TEXT")
+            updated = True
         if 'shop_id' not in purch_cols:
             try:
                 cursor.execute("ALTER TABLE purchases ADD COLUMN shop_id INTEGER DEFAULT 1")
@@ -1548,22 +1560,28 @@ def new_buyer(his_id, username, payed, shop_id=1):
         logging.error(f"Error actualizando comprador: {e}")
         pass
 def new_buy_improved(his_id, username, name_good, amount, price, payment_method="Unknown", payment_id=None, shop_id=1):
-    """Versión mejorada de new_buy que incluye método de pago y timestamp"""
+    """Versión mejorada de new_buy que incluye método de pago, timestamp y expiración"""
     try:
         con = db.get_db_connection()
         cursor = con.cursor()
-        
+
         # Usar timestamp actual
-        from datetime import datetime
+        from datetime import datetime, timedelta
         current_time = datetime.now().isoformat()
-        
+
+        # Calcular expiración si el producto tiene duración
+        duration = get_duration_days(name_good, shop_id)
+        expires_at = None
+        if duration:
+            expires_at = (datetime.now() + timedelta(days=duration)).isoformat()
+
         cursor.execute(
             """
             INSERT INTO purchases
-            (id, username, name_good, amount, price, payment_method, timestamp, shop_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (id, username, name_good, amount, price, payment_method, timestamp, expires_at, shop_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (his_id, username, name_good, amount, price, payment_method, current_time, shop_id)
+            (his_id, username, name_good, amount, price, payment_method, current_time, expires_at, shop_id)
         )
         
         # También insertar en tabla de validación si existe

--- a/expiration_cron.py
+++ b/expiration_cron.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Notify users when their purchases expire."""
+from datetime import datetime
+import db
+from bot_instance import bot
+
+def main():
+    conn = db.get_db_connection()
+    cur = conn.cursor()
+    now = datetime.now().isoformat()
+    cur.execute(
+        "SELECT id, username, name_good, expires_at FROM purchases WHERE expires_at IS NOT NULL AND expires_at <= ?",
+        (now,)
+    )
+    rows = cur.fetchall()
+    for user_id, username, product, expires_at in rows:
+        try:
+            bot.send_message(
+                user_id,
+                f"Tu compra de {product} ha expirado. Vuelve a comprar si deseas renovarla."
+            )
+        except Exception as e:
+            print(f"Error notificando a {user_id}: {e}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_purchase_expiration.py
+++ b/tests/test_purchase_expiration.py
@@ -1,0 +1,28 @@
+import sqlite3
+from datetime import datetime, timedelta
+from tests.test_categories import setup_dop
+
+
+def test_new_buy_improved_sets_expiration(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO goods (name, description, format, minimum, price, stored, duration_days, shop_id) VALUES ('P','d','text',1,5,'x',7,1)"
+    )
+    conn.commit()
+    conn.close()
+
+    assert dop.new_buy_improved(1, 'user', 'P', 1, 5, 'paypal', 'pid', 1)
+
+    conn = sqlite3.connect(tmp_path / "main.db")
+    cur = conn.cursor()
+    cur.execute("SELECT expires_at FROM purchases WHERE id=1 AND name_good='P'")
+    exp = cur.fetchone()[0]
+    conn.close()
+
+    assert exp is not None
+    dt = datetime.fromisoformat(exp)
+    assert dt - datetime.now() > timedelta(days=6)


### PR DESCRIPTION
## Summary
- add `expires_at` column to `purchases` table
- compute expiration when `new_buy_improved` records a purchase
- periodic script `expiration_cron.py` notifies users with expired purchases
- document how to enable purchase expiration notifications
- add regression test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ac7dd227c833398296226148ac461