### PR TITLE
Fix requests mock for tests

### DIFF
--- a/tests/test_payments.py
+++ b/tests/test_payments.py
@@ -39,6 +39,7 @@ def setup_payments(monkeypatch, tmp_path):
             get=lambda *a, **k: None,
             __version__="0",
             Session=lambda *a, **k: types.SimpleNamespace(headers={}),
+            Response=types.SimpleNamespace,
         ),
     )
 

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -63,6 +63,7 @@ def setup_main(monkeypatch, tmp_path):
             get=lambda *a, **k: None,
             __version__="0",
             Session=lambda *a, **k: types.SimpleNamespace(headers={}),
+            Response=types.SimpleNamespace,
         ),
     )
 


### PR DESCRIPTION
## Summary
- extend `requests` mocks in test suite to add `Response`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad665343083338dc65dd6ce4585a4