### PR TITLE
Fix AutoSender config call

### DIFF
--- a/advertising_cron.py
+++ b/advertising_cron.py
@@ -43,7 +43,7 @@ def main():
     if is_running():
         print("AutoSender ya está ejecutándose")
         return
-    auto_sender = AutoSender("data/db/main_data.db")
+    auto_sender = AutoSender(config)
     auto_sender.start()
     print(f"AutoSender iniciado: {datetime.now()}")
 


### PR DESCRIPTION
## Summary
- pass configuration dictionary to `AutoSender`

## Testing
- `pytest -q`
- `python advertising_cron.py` *(with stub modules)*

------
https://chatgpt.com/codex/tasks/task_e_687adec6e3e88333a3b9bd83f7a4de2c