### PR TITLE
Remove debug print in auto_sender

### DIFF
--- a/advertising_system/auto_sender.py
+++ b/advertising_system/auto_sender.py
@@ -101,7 +101,8 @@ class AutoSender:
             for group in groups:
                 group_id = group[0]
                 topic_id = group[1]
-                print(f"🔍 DEBUG: group_id={group_id}, topic_id={topic_id}")  # LÍNEA DEBUG
+                # Debug information about the target group/topic
+                self.logger.debug("group_id=%s, topic_id=%s", group_id, topic_id)
                 try:
                     success, result = telegram_bot.send_message(
                         group_id,


### PR DESCRIPTION
## Summary
- replace manual debug `print` with `self.logger.debug` in `auto_sender`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687adfca372c8333bce589810bea1ce6