### PR TITLE
Add cancel text handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ ellos se incluyen **💬 Respuestas**, **📦 Surtido**, **➕ Producto**, **�
 **📊 Stats**, **Resumen de compradores**, **📣 Difusión**, **📢 Marketing**,
 **💸 Descuentos** y **⚙️ Otros**.
 
+Si en mitad de un proceso quieres detenerte, escribe `/cancel` o pulsa el botón
+*Cancelar* que aparece en muchos diálogos para volver al menú previo.
+
 La opción **Resumen de compradores** genera un listado ordenado por el total
 gastado. Para cada comprador se muestra su ID, nombre de usuario, la suma de sus
 pagos en dólares y los productos adquiridos.

--- a/adminka.py
+++ b/adminka.py
@@ -1060,6 +1060,9 @@ def in_adminka(chat_id, message_text, username, name_user):
 def text_analytics(message_text, chat_id):
     shop_id = dop.get_shop_id(chat_id)
     normalized = message_text.strip().lower()
+    if normalized == 'cancelar':
+        handle_cancel_command(chat_id)
+        return
     if normalized in ('volver al men\u00fa principal', 'volver al menu principal', '/adm'):
         with shelve.open(files.sost_bd) as bd:
             if str(chat_id) in bd:


### PR DESCRIPTION
## Summary
- support typing "Cancelar" to abort admin flows
- clarify in the README that `/cancel` or the *Cancelar* button aborts current actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ae223b1ec83338fa8e000a8675734