### PR TITLE
Handle expired purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,16 +302,25 @@ definida el script terminará con un error.
 
 Si defines la opción **duración en días** para un producto, las compras de ese
 artículo almacenarán su fecha de vencimiento. Para avisar a los usuarios cuando
-una compra haya expirado ejecuta periódicamente `expiration_cron.py` (por
-ejemplo con `cron` o como servicio). El script buscará compras vencidas y
-enviará un mensaje al comprador sugiriendo renovar la adquisición.
+una compra haya expirado ejecuta periódicamente `expiration_cron.py`. El script
+buscará compras vencidas y enviará un mensaje al comprador sugiriendo renovar la
+adquisición. Puedes programarlo con `cron` agregando una línea como la
+siguiente:
+
+```cron
+0 9 * * * cd /ruta/a/Tienda-telegram && TELEGRAM_TOKEN="<tu_token>" python expiration_cron.py
+```
+
+Reemplaza la ruta y el token según corresponda. También puedes ejecutarlo de
+forma puntual con:
 
 ```bash
 python expiration_cron.py
 ```
 
-Al igual que el módulo de marketing, este script utiliza el token configurado en
-`config.py` a través de `bot_instance.py` para enviar las notificaciones.
+`expiration_cron.py` utiliza el token indicado en la variable de entorno
+`TELEGRAM_TOKEN`. Si no se define, tomará el valor configurado en `config.py` a
+través de `bot_instance.py`.
 
 ## Pruebas
 

--- a/expiration_cron.py
+++ b/expiration_cron.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
 """Notify users when their purchases expire."""
 from datetime import datetime
+import os
+from dotenv import load_dotenv
+import telebot
 import db
-from bot_instance import bot
+
+load_dotenv()
+
+def get_bot():
+    token = os.getenv("TELEGRAM_TOKEN")
+    if token:
+        token = token.split(",")[0].strip()
+        if token:
+            return telebot.TeleBot(token)
+    from bot_instance import bot
+    return bot
 
 def main():
+    bot = get_bot()
     conn = db.get_db_connection()
     cur = conn.cursor()
     now = datetime.now().isoformat()

--- a/tests/test_expiration_cron.py
+++ b/tests/test_expiration_cron.py
@@ -1,0 +1,33 @@
+import importlib, sys, sqlite3, types
+
+
+def test_expiration_cron_uses_env_token(monkeypatch, tmp_path):
+    sent = []
+
+    class DummyBot:
+        def __init__(self, token):
+            self.token = token
+        def send_message(self, cid, text):
+            sent.append((cid, text))
+
+    monkeypatch.setenv("TELEGRAM_TOKEN", "x")
+    sys.modules["telebot"] = types.SimpleNamespace(TeleBot=lambda t: DummyBot(t))
+    sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+
+    import files
+    monkeypatch.setattr(files, "main_db", str(tmp_path / "main.db"))
+
+    conn = sqlite3.connect(files.main_db)
+    conn.execute(
+        "CREATE TABLE purchases (id INTEGER, username TEXT, name_good TEXT, amount INTEGER, price INTEGER, payment_method TEXT, timestamp TEXT, expires_at TEXT, shop_id INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO purchases VALUES (1, 'u', 'P', 1, 5, 'paypal', 't', '2000-01-01T00:00:00', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    expiration_cron = importlib.reload(importlib.import_module("expiration_cron"))
+    expiration_cron.main()
+
+    assert sent == [(1, 'Tu compra de P ha expirado. Vuelve a comprar si deseas renovarla.')]


### PR DESCRIPTION
## Summary
- allow overriding token in `expiration_cron.py` via `TELEGRAM_TOKEN`
- document how to schedule `expiration_cron.py`
- test that `expiration_cron.py` uses the env token

## Testing
- `pytest -q tests/test_purchase_expiration.py::test_new_buy_improved_sets_expiration tests/test_expiration_cron.py::test_expiration_cron_uses_env_token -vv`

------
https://chatgpt.com/codex/tasks/task_e_687ae3c0dc008333b26fb3fa3bb7cb07