### PR TITLE
Handle long stock lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ aparecen tres opciones:
 
 Después de cada acción se vuelve al menú de productos.
 
+Si el stock es muy extenso y el mensaje supera los 4096 caracteres que permite
+Telegram, el bot lo envía en varias partes automáticamente.
+
 Al crear una nueva posición se preguntará ahora **¿Entrega manual?**. Si respondes
 *Sí*, el bot omitirá el formato del producto y utilizará el mensaje configurado
 anteriormente para avisar al comprador.

--- a/adminka.py
+++ b/adminka.py
@@ -1614,7 +1614,7 @@ def text_analytics(message_text, chat_id):
                     with open(file_path, 'r', encoding='utf-8') as f:
                         lines = [ln.rstrip('\n') for ln in f.readlines()]
                     text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
+                    dop.send_long_text(bot, chat_id, f'Unidades actuales:\n{text}\n\nEnvía "número nuevo_valor" para reemplazar la línea:')
                     with shelve.open(files.sost_bd) as bd:
                         bd[str(chat_id)] = 181
                 elif action == 'eliminar unidades':
@@ -1627,7 +1627,7 @@ def text_analytics(message_text, chat_id):
                     with open(file_path, 'r', encoding='utf-8') as f:
                         lines = [ln.rstrip('\n') for ln in f.readlines()]
                     text = '\n'.join(f'{i+1}. {line}' for i, line in enumerate(lines)) or 'Sin unidades'
-                    bot.send_message(chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
+                    dop.send_long_text(bot, chat_id, f'Unidades actuales:\n{text}\n\nIndique los números de línea a eliminar separados por espacios:')
                     with shelve.open(files.sost_bd) as bd:
                         bd[str(chat_id)] = 182
                 else:

--- a/dop.py
+++ b/dop.py
@@ -352,6 +352,12 @@ def safe_edit_message(bot, message, text, reply_markup=None, parse_mode=None):
             return False
 
 
+def send_long_text(bot, chat_id, text, parse_mode=None):
+    """Send a message split in chunks of 4096 characters."""
+    for i in range(0, len(text), 4096):
+        bot.send_message(chat_id, text[i:i + 4096], parse_mode=parse_mode)
+
+
 def it_first(chat_id):
     try:
         with open(files.working_log, encoding='utf-8') as f:

--- a/tests/test_long_stock_messages.py
+++ b/tests/test_long_stock_messages.py
@@ -1,0 +1,19 @@
+from tests.test_categories import setup_dop
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    def send_message(self, chat_id, text, parse_mode=None):
+        self.messages.append(text)
+
+
+def test_send_long_text_splits_long_messages(monkeypatch, tmp_path):
+    dop = setup_dop(monkeypatch, tmp_path)
+    long_text = 'X' * 9000
+    bot = DummyBot()
+    dop.send_long_text(bot, 1, long_text)
+
+    assert len(bot.messages) > 1
+    assert ''.join(bot.messages) == long_text


### PR DESCRIPTION
## Summary
- support splitting long messages in `send_long_text`
- use the helper when editing or deleting units
- document long message splitting in README
- test helper to ensure long text is split

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0e4c1e4083338ad301d29a2533a7