### PR TITLE
Fix campaign caption limits and improve scheduling

### DIFF
--- a/advertising_system/scheduler.py
+++ b/advertising_system/scheduler.py
@@ -107,8 +107,9 @@ class CampaignScheduler:
                        c.button1_text, c.button1_url, c.button2_text, c.button2_url
                    FROM campaign_schedules cs
                    JOIN campaigns c ON cs.campaign_id = c.id
-                   WHERE cs.is_active = 1 AND c.status = 'active' AND cs.shop_id = ? AND c.shop_id = ?""",
-            (self.shop_id, self.shop_id),
+                   WHERE cs.is_active = 1 AND c.status = 'active' AND cs.shop_id = ? AND c.shop_id = ?
+                         AND (cs.next_send_telegram IS NULL OR cs.next_send_telegram <= ?)""",
+            (self.shop_id, self.shop_id, now.isoformat()),
         )
         rows = cursor.fetchall()
         pending = []
@@ -138,3 +139,76 @@ class CampaignScheduler:
         conn.commit()
         if not shared:
             conn.close()
+
+    def update_schedule(self, schedule_id, days=None, times=None, platforms=None):
+        """Modificar una programación existente."""
+        conn, shared = self._get_connection()
+        cursor = conn.cursor()
+
+        fields = []
+        params = []
+
+        if days is not None or times is not None:
+            schedule = {}
+            if days is None:
+                days = []
+            norm_days = [self.normalize_day(d) for d in days]
+            for d in norm_days:
+                schedule[d] = times or []
+            fields.append("schedule_json = ?")
+            params.append(json.dumps(schedule))
+
+        if platforms is not None:
+            fields.append("target_platforms = ?")
+            params.append(','.join(platforms))
+
+        if not fields:
+            if not shared:
+                conn.close()
+            return False
+
+        params.extend([schedule_id, self.shop_id])
+        cursor.execute(
+            f"UPDATE campaign_schedules SET {', '.join(fields)} WHERE id = ? AND shop_id = ?",
+            params,
+        )
+        conn.commit()
+        success = cursor.rowcount > 0
+        if not shared:
+            conn.close()
+        return success
+
+    def _reindex_schedules(self, cursor):
+        cursor.execute(
+            "SELECT id FROM campaign_schedules WHERE shop_id = ? ORDER BY id",
+            (self.shop_id,),
+        )
+        ids = [r[0] for r in cursor.fetchall()]
+        for idx, old_id in enumerate(ids, start=1):
+            if old_id != idx:
+                cursor.execute(
+                    "UPDATE campaign_schedules SET id = ? WHERE id = ?",
+                    (-idx, old_id),
+                )
+        for idx, old_id in enumerate(ids, start=1):
+            if old_id != idx:
+                cursor.execute(
+                    "UPDATE campaign_schedules SET id = ? WHERE id = ?",
+                    (idx, -idx),
+                )
+
+    def delete_schedule(self, schedule_id):
+        """Eliminar una programación y reindexar"""
+        conn, shared = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM campaign_schedules WHERE id = ? AND shop_id = ?",
+            (schedule_id, self.shop_id),
+        )
+        deleted = cursor.rowcount > 0
+        if deleted:
+            self._reindex_schedules(cursor)
+        conn.commit()
+        if not shared:
+            conn.close()
+        return deleted

--- a/advertising_system/telegram_multi.py
+++ b/advertising_system/telegram_multi.py
@@ -4,6 +4,8 @@ import random
 from threading import Lock
 
 class TelegramMultiBot:
+    MAX_CAPTION_LENGTH = 1024
+
     def __init__(self, tokens):
         self.bots = [telebot.TeleBot(token) for token in tokens]
         self.current_bot = 0
@@ -47,6 +49,8 @@ class TelegramMultiBot:
                 send_params['message_thread_id'] = topic_id
                 
             if media_file_id:
+                if message and len(message) > self.MAX_CAPTION_LENGTH:
+                    message = message[: self.MAX_CAPTION_LENGTH - 1] + "…"
                 if media_type == 'photo':
                     bot.send_photo(caption=message, photo=media_file_id, **send_params)
                 elif media_type == 'video':
@@ -79,5 +83,7 @@ class TelegramMultiBot:
             elif "too many requests" in error_msg.lower():
                 time.sleep(random.uniform(5, 10))
                 return False, "Rate limit excedido"
+            elif "caption is too long" in error_msg.lower():
+                return False, "Caption demasiado largo"
             else:
                 return False, f"Error: {error_msg}"

--- a/tests/test_caption_truncation.py
+++ b/tests/test_caption_truncation.py
@@ -1,0 +1,31 @@
+import importlib, sys, types
+
+class DummyTeleBot:
+    def __init__(self, token):
+        self.sent = {}
+    def send_photo(self, photo=None, caption=None, **kw):
+        self.sent['caption'] = caption
+    def send_video(self, video=None, caption=None, **kw):
+        self.sent['caption'] = caption
+    def send_document(self, document=None, caption=None, **kw):
+        self.sent['caption'] = caption
+    def send_message(self, *a, **k):
+        self.sent['text'] = k.get('text')
+
+
+def test_caption_is_truncated(monkeypatch):
+    sys.modules.pop('advertising_system.telegram_multi', None)
+    telebot_stub = types.SimpleNamespace(
+        TeleBot=DummyTeleBot,
+        types=types.SimpleNamespace(
+            InlineKeyboardMarkup=lambda *a, **k: None,
+            InlineKeyboardButton=lambda *a, **k: None,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, 'telebot', telebot_stub)
+    tele_mod = importlib.import_module('advertising_system.telegram_multi')
+    bot = tele_mod.TelegramMultiBot(['t'])
+    long_text = 'x' * 1050
+    ok, _ = bot.send_message('g', long_text, media_file_id='id', media_type='photo')
+    assert ok
+    assert len(bot.bots[0].sent['caption']) <= 1024

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -60,3 +60,74 @@ def test_get_pending_sends_json(monkeypatch, tmp_path):
     rows = sch.get_pending_sends()
     assert len(rows) == 1
 
+
+def test_get_pending_sends_respects_next_send(monkeypatch, tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(CREATE_SHOPS)
+    cur.execute(CREATE_CAMPAIGNS)
+    cur.execute(CREATE_SCHEDULES)
+    cur.execute(
+        "INSERT INTO campaigns (name, message_text, media_file_id, media_type, button1_text, button1_url, button2_text, button2_url, status, shop_id)"
+        " VALUES ('c','m',NULL,NULL,NULL,NULL,NULL,NULL,'active',1)"
+    )
+    camp_id = cur.lastrowid
+    schedule = {"lunes": ["10:00"]}
+    cur.execute(
+        "INSERT INTO campaign_schedules (campaign_id, schedule_name, frequency, schedule_json, target_platforms, is_active, next_send_telegram, created_date, shop_id) VALUES (?,?,?,?,?,1,?,'now',1)",
+        (camp_id, 'manual', 'weekly', json.dumps(schedule), 'telegram', '2023-01-03T10:00:00'),
+    )
+    conn.commit()
+    conn.close()
+
+    import advertising_system.scheduler as mod
+    class DummyDatetime(mod.datetime):
+        @classmethod
+        def now(cls):
+            return cls(2023, 1, 2, 10, 0)  # Monday
+    monkeypatch.setattr(mod, 'datetime', DummyDatetime)
+
+    sch = CampaignScheduler(str(db_path))
+    rows = sch.get_pending_sends()
+    assert rows == []
+
+
+def test_update_and_reindex(monkeypatch, tmp_path):
+    db_path = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(CREATE_SHOPS)
+    cur.execute(CREATE_CAMPAIGNS)
+    cur.execute(CREATE_SCHEDULES)
+    cur.execute(
+        "INSERT INTO campaigns (name, message_text, media_file_id, media_type, button1_text, button1_url, button2_text, button2_url, status, shop_id)"
+        " VALUES ('c','m',NULL,NULL,NULL,NULL,NULL,NULL,'active',1)"
+    )
+    camp_id = cur.lastrowid
+    schedule = {"lunes": ["10:00"]}
+    cur.execute(
+        "INSERT INTO campaign_schedules (campaign_id, schedule_name, frequency, schedule_json, target_platforms, is_active, created_date, shop_id) VALUES (?,?,?,?,?,1,'now',1)",
+        (camp_id, 'manual', 'weekly', json.dumps(schedule), 'telegram'),
+    )
+    cur.execute(
+        "INSERT INTO campaign_schedules (campaign_id, schedule_name, frequency, schedule_json, target_platforms, is_active, created_date, shop_id) VALUES (?,?,?,?,?,1,'now',1)",
+        (camp_id, 'manual', 'weekly', json.dumps(schedule), 'telegram'),
+    )
+    conn.commit()
+    conn.close()
+
+    sch = CampaignScheduler(str(db_path))
+    assert sch.update_schedule(2, ['martes'], ['12:00'], ['telegram'])
+    assert sch.delete_schedule(1)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT id, schedule_json FROM campaign_schedules ORDER BY id")
+    rows = cur.fetchall()
+    conn.close()
+
+    assert rows[0][0] == 1
+    data = json.loads(rows[0][1])
+    assert data == {'tuesday': ['12:00']}
+


### PR DESCRIPTION
## Summary
- prevent overlong captions when sending Telegram media
- skip already sent schedules in `get_pending_sends`
- support editing and deleting campaign schedules with reindexing
- add regression tests for scheduler and caption handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c5c989a6c8333a4de06026af00785