### PR TITLE
Support group-based campaign schedules

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -722,10 +722,31 @@ def in_adminka(chat_id, message_text, username, name_user):
                         camp_id = int(parts[0])
                         days = parts[1].split(',')
                         times = parts[2:4]
-                        ok, msg = advertising.schedule_campaign(camp_id, days, times)
-                        bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
                     except ValueError:
                         bot.send_message(chat_id, '❌ ID de campaña inválido')
+                        return
+
+                    groups = advertising.get_target_groups()
+                    if not groups:
+                        ok, msg = advertising.schedule_campaign(camp_id, days, times)
+                        bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
+                    else:
+                        markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                        for g in groups:
+                            title = g['group_name'] or g['group_id']
+                            label = f"{title} ({g['id']})"
+                            if g.get('topic_id') is not None:
+                                label += f" (topic {g['topic_id']})"
+                            markup.row(label)
+                        markup.row('Todos', 'Cancelar')
+
+                        os.makedirs('data/Temp', exist_ok=True)
+                        tmp = f'data/Temp/{chat_id}_schedule.json'
+                        with open(tmp, 'w', encoding='utf-8') as f:
+                            json.dump({'type': 'create', 'camp_id': camp_id, 'days': days, 'times': times, 'groups': groups}, f)
+
+                        bot.send_message(chat_id, 'Seleccione los grupos destino (enviar IDs separados por coma o "Todos"):', reply_markup=markup)
+                        set_state(chat_id, 187, 'marketing')
 
         elif '📆 Programaciones' == message_text:
             conn = db.get_db_connection()
@@ -1793,16 +1814,36 @@ def text_analytics(message_text, chat_id):
                 return
             days = parts[0].split(',')
             times = parts[1:]
-            scheduler = CampaignScheduler(files.main_db, shop_id)
-            ok = scheduler.update_schedule(schedule_id, days, times)
-            bot.send_message(chat_id, '✅ Programación actualizada' if ok else '❌ Error actualizando programación')
-            with shelve.open(files.sost_bd) as bd:
-                del bd[str(chat_id)]
-            try:
-                os.remove(path)
-            except Exception:
-                pass
-            show_marketing_menu(chat_id)
+
+            groups = advertising.get_target_groups()
+            if not groups:
+                scheduler = CampaignScheduler(files.main_db, shop_id)
+                ok = scheduler.update_schedule(schedule_id, days, times)
+                bot.send_message(chat_id, '✅ Programación actualizada' if ok else '❌ Error actualizando programación')
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                try:
+                    os.remove(path)
+                except Exception:
+                    pass
+                show_marketing_menu(chat_id)
+            else:
+                markup = telebot.types.ReplyKeyboardMarkup(True, False)
+                for g in groups:
+                    title = g['group_name'] or g['group_id']
+                    label = f"{title} ({g['id']})"
+                    if g.get('topic_id') is not None:
+                        label += f" (topic {g['topic_id']})"
+                    markup.row(label)
+                markup.row('Todos', 'Cancelar')
+
+                os.makedirs('data/Temp', exist_ok=True)
+                tmp = f'data/Temp/{chat_id}_schedule.json'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    json.dump({'type': 'edit', 'schedule_id': schedule_id, 'days': days, 'times': times, 'groups': groups}, f)
+
+                bot.send_message(chat_id, 'Seleccione los grupos destino (enviar IDs separados por coma o "Todos"):', reply_markup=markup)
+                set_state(chat_id, 187, 'marketing')
 
         elif sost_num == 18:
             # PayPal Client ID
@@ -2621,6 +2662,44 @@ def text_analytics(message_text, chat_id):
                     return
                 ok, msg = advertising.send_campaign_to_group(camp_id, selected['group_id'], selected.get('topic_id'))
                 bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                show_marketing_menu(chat_id)
+
+        elif sost_num == 187:
+            tmp = f'data/Temp/{chat_id}_schedule.json'
+            if message_text.lower() == 'cancelar':
+                with shelve.open(files.sost_bd) as bd:
+                    del bd[str(chat_id)]
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                show_marketing_menu(chat_id)
+            else:
+                try:
+                    with open(tmp, 'r', encoding='utf-8') as f:
+                        data = json.load(f)
+                except FileNotFoundError:
+                    session_expired(chat_id)
+                    return
+
+                ids = None
+                if message_text.lower() not in ('todos', '0'):
+                    ids = [int(i) for i in re.findall(r"\d+", message_text)]
+
+                if data['type'] == 'create':
+                    ok, msg = advertising.schedule_campaign(
+                        data['camp_id'], data['days'], data['times'], group_ids=ids
+                    )
+                    bot.send_message(chat_id, ('✅ ' if ok else '❌ ') + msg)
+                else:
+                    scheduler = CampaignScheduler(files.main_db, shop_id)
+                    ok = scheduler.update_schedule(
+                        data['schedule_id'], data['days'], data['times'], group_ids=ids
+                    )
+                    bot.send_message(chat_id, '✅ Programación actualizada' if ok else '❌ Error actualizando programación')
+
                 with shelve.open(files.sost_bd) as bd:
                     del bd[str(chat_id)]
                 if os.path.exists(tmp):

--- a/advertising_system/ad_manager.py
+++ b/advertising_system/ad_manager.py
@@ -96,7 +96,7 @@ class AdvertisingManager:
             self.logger.error(f"Error deleting campaign: {e}")
             return False
 
-    def schedule_campaign(self, campaign_id, days, times, platforms=None):
+    def schedule_campaign(self, campaign_id, days, times, platforms=None, group_ids=None):
         """Programar una campaña para enviarse en días y horas específicas."""
         if platforms is None:
             platforms = ['telegram']
@@ -150,8 +150,8 @@ class AdvertisingManager:
             cur.execute(
                 """INSERT INTO campaign_schedules
                    (campaign_id, schedule_name, frequency, schedule_json,
-                    target_platforms, created_date, shop_id)
-                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    target_platforms, created_date, shop_id, group_ids)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     campaign_id,
                     'manual',
@@ -160,6 +160,7 @@ class AdvertisingManager:
                     ','.join(platforms),
                     datetime.now().isoformat(),
                     self.shop_id,
+                    ','.join(map(str, group_ids)) if group_ids else None,
                 ),
             )
             conn.commit()

--- a/advertising_system/auto_sender.py
+++ b/advertising_system/auto_sender.py
@@ -59,9 +59,25 @@ class AutoSender:
         cursor = conn.cursor()
         
         try:
-            cursor.execute('SELECT group_id, topic_id FROM target_groups WHERE status = "active" AND shop_id = ?', 
-                          (self.scheduler.shop_id,))
-            groups = cursor.fetchall()
+            group_ids = None
+            if campaign_data and len(campaign_data) > 10:
+                group_ids = campaign_data[10]
+
+            if group_ids:
+                ids = [int(g) for g in str(group_ids).split(',') if g]
+                if ids:
+                    placeholders = ','.join('?' for _ in ids)
+                    cursor.execute(
+                        f'SELECT group_id, topic_id FROM target_groups WHERE status = "active" AND shop_id = ? AND id IN ({placeholders})',
+                        [self.scheduler.shop_id, *ids]
+                    )
+                    groups = cursor.fetchall()
+                else:
+                    groups = []
+            else:
+                cursor.execute('SELECT group_id, topic_id FROM target_groups WHERE status = "active" AND shop_id = ?',
+                              (self.scheduler.shop_id,))
+                groups = cursor.fetchall()
             
             if not groups:
                 return

--- a/advertising_system/scheduler.py
+++ b/advertising_system/scheduler.py
@@ -74,8 +74,8 @@ class CampaignScheduler:
         cursor = conn.cursor()
         cursor.execute(
             """INSERT INTO campaign_schedules
-               (campaign_id, schedule_name, frequency, schedule_json, target_platforms, created_date, shop_id)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (campaign_id, schedule_name, frequency, schedule_json, target_platforms, created_date, shop_id, group_ids)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 data['campaign_id'],
                 'auto',
@@ -84,6 +84,7 @@ class CampaignScheduler:
                 data['platform'],
                 datetime.now().isoformat(),
                 data.get('shop_id', self.shop_id),
+                ','.join(map(str, data.get('group_ids', []))) if data.get('group_ids') else None,
             )
         )
         conn.commit()
@@ -140,7 +141,7 @@ class CampaignScheduler:
         if not shared:
             conn.close()
 
-    def update_schedule(self, schedule_id, days=None, times=None, platforms=None):
+    def update_schedule(self, schedule_id, days=None, times=None, platforms=None, group_ids=None):
         """Modificar una programación existente."""
         conn, shared = self._get_connection()
         cursor = conn.cursor()
@@ -161,6 +162,10 @@ class CampaignScheduler:
         if platforms is not None:
             fields.append("target_platforms = ?")
             params.append(','.join(platforms))
+
+        if group_ids is not None:
+            fields.append("group_ids = ?")
+            params.append(','.join(map(str, group_ids)) if group_ids else None)
 
         if not fields:
             if not shared:

--- a/init_db.py
+++ b/init_db.py
@@ -156,6 +156,7 @@ def create_database():
             next_send_telegram TEXT,
             created_date TEXT,
             shop_id INTEGER DEFAULT 1,
+            group_ids TEXT,
             FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
         )
     ''')

--- a/tests/test_advertising.py
+++ b/tests/test_advertising.py
@@ -83,6 +83,7 @@ CREATE_SCHEDULES_TABLE = """CREATE TABLE IF NOT EXISTS campaign_schedules (
     next_send_telegram TEXT,
     created_date TEXT,
     shop_id INTEGER DEFAULT 1,
+    group_ids TEXT,
     FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
 )"""
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -26,7 +26,8 @@ CREATE_SCHEDULES = """CREATE TABLE campaign_schedules (
     is_active INTEGER DEFAULT 1,
     next_send_telegram TEXT,
     created_date TEXT,
-    shop_id INTEGER DEFAULT 1
+    shop_id INTEGER DEFAULT 1,
+    group_ids TEXT
 )"""
 
 CREATE_SHOPS = """CREATE TABLE shops (id INTEGER PRIMARY KEY AUTOINCREMENT, admin_id INTEGER, name TEXT)"""

--- a/tests/test_topic_send.py
+++ b/tests/test_topic_send.py
@@ -62,6 +62,7 @@ CREATE_SCHEDULES_TABLE = """CREATE TABLE IF NOT EXISTS campaign_schedules (
     next_send_telegram TEXT,
     created_date TEXT,
     shop_id INTEGER DEFAULT 1,
+    group_ids TEXT,
     FOREIGN KEY (campaign_id) REFERENCES campaigns (id)
 )"""
 


### PR DESCRIPTION
## Summary
- allow specifying target groups when creating or editing campaign schedules
- store optional `group_ids` in `campaign_schedules`
- update scheduler and ad manager to persist `group_ids`
- use `group_ids` in AutoSender to filter groups
- adjust admin interface and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8396caa08333b8937809090783bb