### PR TITLE
Add migration for campaign group_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ ejecuta:
 python migrate_create_bot_groups.py
 ```
 
+Si la tabla `campaign_schedules` no incluye la columna `group_ids`, ejecuta:
+
+```bash
+python migrate_add_group_ids.py
+```
+o `init_db.py` para crear la base desde cero.
+
 Por último, si la tabla `goods` aún no utiliza `(name, shop_id)` como clave
 primaria ejecuta:
 

--- a/migrate_add_group_ids.py
+++ b/migrate_add_group_ids.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""Add group_ids column to campaign_schedules table."""
+import sqlite3
+
+
+def main():
+    conn = sqlite3.connect('data/db/main_data.db')
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(campaign_schedules)")
+    cols = [c[1] for c in cur.fetchall()]
+    if 'group_ids' not in cols:
+        cur.execute("ALTER TABLE campaign_schedules ADD COLUMN group_ids TEXT")
+        print("\u2713 Columna 'group_ids' agregada a 'campaign_schedules'")
+    else:
+        print("\u2139\ufe0f La tabla 'campaign_schedules' ya tiene 'group_ids'")
+    conn.commit()
+    print("\u2713 Migraci\u00f3n completada")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `migrate_add_group_ids.py` script for `campaign_schedules`
- document new migration step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8db4e5fc8333b1f9081d7cfb0fe2