### PR TITLE
Add schedule listing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,16 @@ con comandos para gestionar campañas:
   de grupos objetivo para seleccionar. Si un destino corresponde a un topic
   específico aparecerá como `Nombre (ID) (topic <topic_id>)`.
 
+Para consultar desde la terminal qué grupos tiene asignados cada horario puedes
+ejecutar:
+
+```bash
+python list_schedules.py
+```
+
+El script imprimirá los pares `group_id/topic_id` correspondientes a cada
+programación registrada.
+
 La *Campaña de producto* permite seleccionar uno de los artículos ya creados y
 enviar su información como anuncio. El bot añadirá automáticamente un botón que
 apunta al producto usando un enlace profundo, de modo que al abrirlo se muestren

--- a/list_schedules.py
+++ b/list_schedules.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Display campaign schedules and their target groups."""
+
+import sqlite3
+import files
+
+
+def main():
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+
+    cur.execute(
+        "SELECT id, schedule_name, group_ids FROM campaign_schedules ORDER BY id"
+    )
+    schedules = cur.fetchall()
+
+    if not schedules:
+        print("No hay programaciones registradas")
+        return
+
+    for sched_id, name, group_ids in schedules:
+        print(f"\nProgramación {sched_id}: {name}")
+        groups = []
+        if group_ids:
+            ids = [int(g) for g in str(group_ids).split(',') if g.strip()]
+            if ids:
+                placeholders = ",".join("?" for _ in ids)
+                cur.execute(
+                    f"SELECT group_id, topic_id FROM target_groups WHERE id IN ({placeholders})",
+                    ids,
+                )
+                groups = cur.fetchall()
+        if not groups:
+            print("  (sin grupos asociados)")
+        else:
+            for gid, topic in groups:
+                topic_str = f"/{topic}" if topic is not None else ""
+                print(f"  {gid}{topic_str}")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `list_schedules.py` for reporting campaign schedules
- document the tool in the Marketing section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c93aebc1c8333b6c7aa0527f69b92