### PR TITLE
Add telegram campaign alias

### DIFF
--- a/advertising_system/auto_sender.py
+++ b/advertising_system/auto_sender.py
@@ -216,6 +216,10 @@ class AutoSender:
             print(f"❌ Error en _send_telegram_campaign_corrected: {e}")
             return False
 
+    def _send_telegram_campaign(self, campaign_id, schedule_id, send_data):
+        """Backward compatible wrapper for `_send_telegram_campaign_corrected`."""
+        return self._send_telegram_campaign_corrected(campaign_id, schedule_id, send_data)
+
     def start(self) -> bool:
         print(f"AutoSender iniciado: {datetime.now()}")
         return self.process_campaigns()

--- a/tests/test_auto_sender.py
+++ b/tests/test_auto_sender.py
@@ -228,5 +228,5 @@ def test_send_without_group_ids_column(tmp_path, monkeypatch):
     sender = AutoSender({'db_path': str(db_path), 'telegram_tokens': ['t']})
     monkeypatch.setattr(sender.scheduler, 'update_next_send', lambda *a, **k: None)
 
-    sender._send_telegram_campaign_corrected(camp_id, schedule_id, row)
+    sender._send_telegram_campaign(camp_id, schedule_id, row)
     assert len(DummyTeleBot.calls) == 2

--- a/tests/test_topic_send.py
+++ b/tests/test_topic_send.py
@@ -179,7 +179,7 @@ def test_auto_sender_topic_groups(tmp_path, monkeypatch):
     sender = AutoSender({'db_path': str(db_path), 'telegram_tokens': ['t']})
     monkeypatch.setattr(sender.scheduler, 'update_next_send', lambda *a, **k: None)
 
-    sender._send_telegram_campaign_corrected(camp_id, schedule_id, row)
+    sender._send_telegram_campaign(camp_id, schedule_id, row)
     assert DummyTeleBot.calls == [1, 2]
 
 
@@ -219,5 +219,5 @@ def test_auto_sender_respects_group_ids(tmp_path, monkeypatch):
     sender = AutoSender({'db_path': str(db_path), 'telegram_tokens': ['t']})
     monkeypatch.setattr(sender.scheduler, 'update_next_send', lambda *a, **k: None)
 
-    sender._send_telegram_campaign_corrected(camp_id, schedule_id, row)
+    sender._send_telegram_campaign(camp_id, schedule_id, row)
     assert DummyTeleBotWithGroup.calls == [('g2', 2)]


### PR DESCRIPTION
## Summary
- add `_send_telegram_campaign` alias in auto sender
- update tests to use the alias

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817c9b15e88333898816878ea9e876