### PR TITLE
Improve schedule listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,15 +295,17 @@ con comandos para gestionar campañas:
   de grupos objetivo para seleccionar. Si un destino corresponde a un topic
   específico aparecerá como `Nombre (ID) (topic <topic_id>)`.
 
-Para consultar desde la terminal qué grupos tiene asignados cada horario puedes
-ejecutar:
+Para consultar desde la terminal los horarios y grupos asignados a cada
+programación puedes ejecutar:
 
 ```bash
 python list_schedules.py
 ```
 
-El script imprimirá los pares `group_id/topic_id` correspondientes a cada
-programación registrada.
+El script ahora muestra los campos `schedule_json`, `frequency` y
+`next_send_telegram`, despliega los días y horas configurados (por ejemplo
+`lunes 10:00, 15:00`) e indica si la programación está activa junto con la
+próxima fecha de envío en Telegram, si existe.
 
 La *Campaña de producto* permite seleccionar uno de los artículos ya creados y
 enviar su información como anuncio. El bot añadirá automáticamente un botón que

--- a/list_schedules.py
+++ b/list_schedules.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
-"""Display campaign schedules and their target groups."""
+"""Display campaign schedules, their groups and timing info."""
 
 import sqlite3
+import json
 import files
+
+
+DAY_MAP = {
+    'monday': 'lunes',
+    'tuesday': 'martes',
+    'wednesday': 'miercoles',
+    'thursday': 'jueves',
+    'friday': 'viernes',
+    'saturday': 'sabado',
+    'sunday': 'domingo',
+}
 
 
 def main():
@@ -10,7 +22,9 @@ def main():
     cur = conn.cursor()
 
     cur.execute(
-        "SELECT id, schedule_name, group_ids FROM campaign_schedules ORDER BY id"
+        """SELECT id, schedule_name, frequency, schedule_json, is_active,
+                  next_send_telegram, group_ids
+           FROM campaign_schedules ORDER BY id"""
     )
     schedules = cur.fetchall()
 
@@ -18,8 +32,27 @@ def main():
         print("No hay programaciones registradas")
         return
 
-    for sched_id, name, group_ids in schedules:
-        print(f"\nProgramación {sched_id}: {name}")
+    for sched_id, name, freq, sched_json, active, next_send, group_ids in schedules:
+        estado = "activa" if active else "inactiva"
+        print(f"\nProgramación {sched_id}: {name} ({estado})")
+        if freq:
+            print(f"  Frecuencia: {freq}")
+
+        if sched_json:
+            try:
+                data = json.loads(sched_json)
+            except Exception:
+                data = {}
+            if data:
+                print("  Horarios:")
+                for day, hours in data.items():
+                    d = DAY_MAP.get(day.lower(), day)
+                    if hours:
+                        print(f"    {d} {', '.join(hours)}")
+
+        if next_send:
+            print(f"  Próximo envío Telegram: {next_send}")
+
         groups = []
         if group_ids:
             ids = [int(g) for g in str(group_ids).split(',') if g.strip()]


### PR DESCRIPTION
## Summary
- show campaign schedule details when listing
- document new schedule info in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68817fd905d08333baa4d6e0f9a7fae7