### PR TITLE
Fix advertising_cron path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ una entrada de `cron`:
 python advertising_cron.py
 ```
 
+El script determina su ubicación y la agrega al `PYTHONPATH`, por lo que no
+necesitas modificar rutas manualmente. Asegúrate de lanzarlo desde la carpeta
+del proyecto (o con el directorio de trabajo apuntando allí) para que pueda
+encontrar la base de datos.
+
 Desde el panel de administración aparecerá una nueva opción **📢 Marketing**
 con comandos para gestionar campañas:
 

--- a/advertising_cron.py
+++ b/advertising_cron.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 import sys
 import os
-sys.path.insert(0, '/home/telegram-bot')
+
+# Añade la carpeta del script al `sys.path` para poder importar los módulos
+# del proyecto sin depender de rutas absolutas.
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
 import config
 from bot_instance import bot
 import telebot


### PR DESCRIPTION
## Summary
- add script dir to `sys.path` in `advertising_cron.py`
- note automatic path handling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881ca072ca08333bf5c247ad6a2cb0f