### PR TITLE
Use improved purchase recording

### DIFF
--- a/payments.py
+++ b/payments.py
@@ -506,8 +506,19 @@ def deliver_product(chat_id, username, first_name, name_good, amount, sum_amount
             except Exception as e:
                 logging.error(f"DEBUG: Error notificando admin {admin_id}: {e}")
         
-        # Registrar compra asociada a la tienda del usuario
-        dop.new_buy(chat_id, username, name_good, amount, sum_amount, shop_id)
+        # Registrar compra asociada a la tienda del usuario usando la versión
+        # mejorada que almacena información del método de pago y un ID único
+        payment_id = f"{payment_method}_{chat_id}_{int(time.time())}"
+        dop.new_buy_improved(
+            chat_id,
+            username,
+            name_good,
+            amount,
+            sum_amount,
+            payment_method,
+            payment_id,
+            shop_id,
+        )
         dop.new_buyer(chat_id, username, sum_amount, shop_id)
         
         logging.info(f"DEBUG: Producto entregado exitosamente a {chat_id}")

--- a/tests/test_purchase_record.py
+++ b/tests/test_purchase_record.py
@@ -1,0 +1,39 @@
+from tests.test_payments import setup_payments
+
+
+def test_deliver_product_records_purchase(monkeypatch, tmp_path):
+    payments, _ = setup_payments(monkeypatch, tmp_path)
+    dop = payments.dop
+    dop.ensure_database_schema()
+
+    # Registrar un producto para que get_goodformat devuelva algo coherente
+    dop.create_product("P", "d", "text", 1, 5, "x", shop_id=1)
+
+    # Stubs para simplificar la entrega del producto
+    monkeypatch.setattr(dop, "get_user_shop", lambda cid: 1)
+    monkeypatch.setattr(dop, "is_manual_delivery", lambda name: False)
+    monkeypatch.setattr(dop, "get_goodformat", lambda name: "text")
+    monkeypatch.setattr(dop, "get_tovar", lambda name, shop_id: "data")
+    monkeypatch.setattr(dop, "check_message", lambda *a, **k: False)
+    monkeypatch.setattr(dop, "get_adminlist", lambda: [])
+    monkeypatch.setattr(dop, "new_buyer", lambda *a, **k: None)
+
+    recorded = {}
+
+    def fake_new_buy_improved(*args):
+        recorded["args"] = args
+        return True
+
+    monkeypatch.setattr(dop, "new_buy_improved", fake_new_buy_improved)
+
+    # Fijar el tiempo para un ID predecible
+    monkeypatch.setattr(payments.time, "time", lambda: 12345)
+
+    payments.deliver_product(10, "user", "User", "P", 1, 5, "PayPal")
+
+    assert recorded["args"][0] == 10
+    assert recorded["args"][2] == "P"
+    assert recorded["args"][4] == 5
+    assert recorded["args"][5] == "PayPal"
+    assert recorded["args"][6] == "PayPal_10_12345"
+


### PR DESCRIPTION
## Summary
- ensure payment recording uses new_buy_improved
- test that deliver_product records purchases with payment ID

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882aff0df288333baaf2b3aed9788c5