### PR TITLE
Add unified store dashboard with Telethon stats

### DIFF
--- a/db.py
+++ b/db.py
@@ -109,6 +109,41 @@ def get_user_stores(user_id):
     return stores
 
 
+def get_store_stats(store_id):
+    """Return basic statistics for a store.
+
+    The function is resilient to missing tables and will return zeros if the
+    required data is not available."""
+    stats = {"products": 0, "purchases": 0, "revenue": 0}
+    try:
+        con = get_db_connection()
+        cur = con.cursor()
+
+        try:
+            cur.execute(
+                "SELECT COUNT(*) FROM goods WHERE shop_id = ?",
+                (store_id,),
+            )
+            stats["products"] = cur.fetchone()[0]
+        except Exception:
+            pass
+
+        try:
+            cur.execute(
+                "SELECT COUNT(*), COALESCE(SUM(price),0) FROM purchases WHERE shop_id = ?",
+                (store_id,),
+            )
+            row = cur.fetchone()
+            stats["purchases"] = row[0]
+            stats["revenue"] = row[1]
+        except Exception:
+            pass
+    except Exception:
+        return stats
+
+    return stats
+
+
 def _ensure_global_config_table(cur):
     """Ensure the global_config table exists."""
     cur.execute(

--- a/telethon_manager.py
+++ b/telethon_manager.py
@@ -1,0 +1,33 @@
+import db
+
+
+def get_stats(shop_id):
+    """Return telethon statistics for a store.
+
+    The stats include whether telethon is active and the number of messages
+    sent through the telethon platform for the given shop. Missing tables or
+    data result in default values."""
+    stats = {"active": False, "sent": 0}
+    try:
+        con = db.get_db_connection()
+        cur = con.cursor()
+        try:
+            cur.execute(
+                "SELECT is_active FROM platform_config WHERE platform='telethon' AND shop_id=?",
+                (shop_id,),
+            )
+            row = cur.fetchone()
+            stats["active"] = bool(row[0]) if row else False
+        except Exception:
+            pass
+        try:
+            cur.execute(
+                "SELECT COUNT(*) FROM send_logs WHERE platform='telethon' AND shop_id=?",
+                (shop_id,),
+            )
+            stats["sent"] = cur.fetchone()[0]
+        except Exception:
+            pass
+    except Exception:
+        return stats
+    return stats

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -192,3 +192,15 @@ def test_shop_rating_shown(monkeypatch, tmp_path):
 
     assert "4.5" in text
     assert any(b.text.startswith("⭐") for b in buttons)
+
+
+def test_dashboard_has_telethon_button(monkeypatch, tmp_path):
+    dop, _, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+    import importlib, adminka
+    importlib.reload(adminka)
+    adminka.show_store_dashboard_unified(5, sid, "S1")
+    buttons = calls[-1][2]["reply_markup"].buttons
+    texts = [b.text for b in buttons]
+    assert any("Telethon" in t for t in texts)


### PR DESCRIPTION
## Summary
- Implement unified store dashboard with product, marketing, Telethon and navigation buttons
- Gather store and Telethon statistics and expose via new `telethon_manager`
- Replace old product and marketing menus with unified dashboard and add tests for Telethon button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c621c02c8333a984793415270d30