### PR TITLE
Add message chunker utility and paginate long messages

### DIFF
--- a/streaming_manager_bot.py
+++ b/streaming_manager_bot.py
@@ -2,6 +2,7 @@ import telethon_dashboard
 import telethon_manager
 import telebot
 from bot_instance import bot
+from utils.message_chunker import send_long_message
 
 
 class StreamingManagerBot:
@@ -28,22 +29,22 @@ class StreamingManagerBot:
                     callback_data=f"start_auto_detection_{store_id}_custom",
                 ),
             )
-            self.bot.send_message(chat_id, summary, reply_markup=key)
+            send_long_message(self.bot, chat_id, summary, markup=key)
         elif callback_data.startswith("start_auto_detection_"):
             parts = callback_data.split("_")
             store_id = int(parts[3])
             mode = parts[4] if len(parts) > 4 else "all"
 
             def progress(msg):
-                self.bot.send_message(chat_id, msg)
+                send_long_message(self.bot, chat_id, msg)
 
             telethon_manager.start_auto_detection(store_id, mode, progress)
-            self.bot.send_message(chat_id, "Configuración confirmada")
+            send_long_message(self.bot, chat_id, "Configuración confirmada")
         elif callback_data.startswith("telethon_test_"):
             store_id = int(callback_data.rsplit("_", 1)[1])
             telethon_manager.test_send(store_id)
-            self.bot.send_message(chat_id, "Envío de prueba enviado")
+            send_long_message(self.bot, chat_id, "Envío de prueba enviado")
         elif callback_data.startswith("telethon_restart_"):
             store_id = int(callback_data.rsplit("_", 1)[1])
             telethon_manager.restart_daemon(store_id)
-            self.bot.send_message(chat_id, "Daemon reiniciado")
+            send_long_message(self.bot, chat_id, "Daemon reiniciado")

--- a/telethon_dashboard.py
+++ b/telethon_dashboard.py
@@ -2,6 +2,7 @@ import telebot
 from bot_instance import bot
 import telethon_manager
 from navigation import nav_system
+from utils.message_chunker import send_long_message
 
 
 def show_telethon_dashboard(chat_id, store_id):
@@ -22,4 +23,4 @@ def show_telethon_dashboard(chat_id, store_id):
     key = nav_system.create_universal_navigation(
         chat_id, f"telethon_dashboard_{store_id}", quick_actions
     )
-    bot.send_message(chat_id, "\n".join(lines), reply_markup=key, parse_mode="Markdown")
+    send_long_message(bot, chat_id, "\n".join(lines), markup=key, parse_mode="Markdown")

--- a/tests/test_long_stock_messages.py
+++ b/tests/test_long_stock_messages.py
@@ -1,19 +1,20 @@
-from tests.test_categories import setup_dop
+from utils.message_chunker import send_long_message
 
 
 class DummyBot:
     def __init__(self):
         self.messages = []
 
-    def send_message(self, chat_id, text, parse_mode=None):
+    def send_message(self, chat_id, text, parse_mode=None, reply_markup=None):
         self.messages.append(text)
 
 
-def test_send_long_text_splits_long_messages(monkeypatch, tmp_path):
-    dop = setup_dop(monkeypatch, tmp_path)
+def test_send_long_message_splits_long_messages():
     long_text = 'X' * 9000
     bot = DummyBot()
-    dop.send_long_text(bot, 1, long_text)
+    send_long_message(bot, 1, long_text)
 
-    assert len(bot.messages) > 1
-    assert ''.join(bot.messages) == long_text
+    assert len(bot.messages) == 3
+    assert bot.messages[0].startswith('1/3')
+    reconstructed = ''.join(m.split('\n', 1)[1] if '\n' in m else m for m in bot.messages)
+    assert reconstructed == long_text

--- a/utils/message_chunker.py
+++ b/utils/message_chunker.py
@@ -1,0 +1,30 @@
+import math
+
+
+def send_long_message(bot, chat_id, text, markup=None, parse_mode=None):
+    """Send text in chunks safe for Telegram (<4096 chars).
+
+    Adds a simple page header ("1/3") when the text spans multiple messages.
+    The reply markup, if provided, is only attached to the first message.
+    """
+    if text is None:
+        text = ""
+    MAX = 4096
+    # Determine number of chunks considering header size
+    n = max(1, math.ceil(len(text) / MAX))
+    while True:
+        header_len = len(f"{n}/{n}\n") if n > 1 else 0
+        chunk_size = MAX - header_len
+        new_n = max(1, math.ceil(len(text) / chunk_size))
+        if new_n == n:
+            break
+        n = new_n
+    chunks = [text[i * chunk_size : (i + 1) * chunk_size] for i in range(n)]
+    for idx, chunk in enumerate(chunks, 1):
+        header = f"{idx}/{n}\n" if n > 1 else ""
+        bot.send_message(
+            chat_id,
+            header + chunk,
+            reply_markup=markup if idx == 1 else None,
+            parse_mode=parse_mode,
+        )


### PR DESCRIPTION
## Summary
- Add `utils/message_chunker.py` utility with `send_long_message` to chunk and paginate messages over Telegram's 4096 char limit
- Use `send_long_message` across telethon dashboard, wizard, and callback router
- Test long message splitting with simulated data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689364458a408333a1576fe16eeb8177