### PR TITLE
Add global metrics dashboard

### DIFF
--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -1,0 +1,50 @@
+import db
+from bot_instance import bot
+from navigation import nav_system
+from utils.message_chunker import send_long_message
+
+
+def show_global_metrics(chat_id, user_id):
+    """Display global ROI, ranking, alerts and Telethon state."""
+    if db.get_user_role(user_id) != 'superadmin':
+        bot.send_message(chat_id, '❌ Acceso restringido.')
+        return
+
+    metrics = db.get_global_metrics()
+    alerts = db.get_alerts()
+
+    lines = [
+        '🌐 *Métricas Globales*',
+        f"ROI: {metrics.get('roi', 0)}",
+        f"Telethon: {metrics.get('telethon_active', 0)}/{metrics.get('telethon_total', 0)} activos",
+        '',
+        '*Ranking:*',
+    ]
+    for idx, r in enumerate(metrics.get('ranking', []), 1):
+        lines.append(f"{idx}. {r.get('name')} - ${r.get('total')}")
+
+    if alerts:
+        lines.append('\n*Alertas recientes:*')
+        for a in alerts:
+            lines.append(f"{a.get('level')}: {a.get('message')}")
+    else:
+        lines.append('\n*Alertas recientes:* Ninguna')
+
+    key = nav_system.create_universal_navigation(
+        chat_id,
+        'global_metrics',
+        [
+            ('🔄 Actualizar', 'global_metrics'),
+            ('📊 Reportes', 'global_metrics'),
+            ('⚠️ Alertas', 'global_metrics'),
+        ],
+    )
+    send_long_message(bot, chat_id, '\n'.join(lines), markup=key, parse_mode='Markdown')
+    db.log_event('INFO', f'global_metrics viewed by {user_id}')
+
+
+def _global_metrics_nav(chat_id, _store_id=None):
+    show_global_metrics(chat_id, chat_id)
+
+
+nav_system.register('global_metrics', _global_metrics_nav)

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -1,0 +1,88 @@
+import types
+import pathlib, sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from metrics_dashboard import show_global_metrics
+
+
+class DummyBot:
+    def __init__(self):
+        self.messages = []
+
+    def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+        self.messages.append((chat_id, text, reply_markup))
+
+
+def test_show_global_metrics_access_denied(monkeypatch):
+    import metrics_dashboard
+
+    dummy = DummyBot()
+    monkeypatch.setattr(metrics_dashboard, 'bot', dummy)
+    monkeypatch.setattr(metrics_dashboard.db, 'get_user_role', lambda uid: 'user')
+
+    show_global_metrics(1, 2)
+
+    assert any('Acceso restringido' in m[1] for m in dummy.messages)
+
+
+def test_show_global_metrics_content(monkeypatch):
+    import metrics_dashboard
+
+    dummy = DummyBot()
+    monkeypatch.setattr(metrics_dashboard, 'bot', dummy)
+    monkeypatch.setattr(metrics_dashboard.db, 'get_user_role', lambda uid: 'superadmin')
+    monkeypatch.setattr(
+        metrics_dashboard.db,
+        'get_global_metrics',
+        lambda: {
+            'roi': 10,
+            'ranking': [{'name': 'Shop1', 'total': 100}],
+            'telethon_active': 1,
+            'telethon_total': 2,
+        },
+    )
+    monkeypatch.setattr(
+        metrics_dashboard.db,
+        'get_alerts',
+        lambda limit=5: [{'level': 'ERROR', 'message': 'Algo'}],
+    )
+    events = []
+    monkeypatch.setattr(
+        metrics_dashboard.db,
+        'log_event',
+        lambda level, message, store_id=None: events.append((level, message, store_id)),
+    )
+
+    class Markup:
+        def __init__(self):
+            self.keyboard = []
+
+        def add(self, *btns):
+            self.keyboard.append(list(btns))
+
+    class Button:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    stub = types.SimpleNamespace(
+        types=types.SimpleNamespace(
+            InlineKeyboardMarkup=Markup, InlineKeyboardButton=Button
+        )
+    )
+    monkeypatch.setitem(sys.modules, 'telebot', stub)
+
+    show_global_metrics(1, 1)
+
+    text = '\n'.join(m[1] for m in dummy.messages)
+    assert 'ROI: 10' in text
+    assert 'Shop1' in text
+    assert 'Telethon: 1/2 activos' in text
+    assert 'ERROR: Algo' in text
+
+    markup = dummy.messages[0][2]
+    buttons = [btn for row in markup.keyboard for btn in row if btn.callback_data == 'global_metrics']
+    texts = [b.text for b in buttons]
+    assert texts == ['🔄 Actualizar', '📊 Reportes', '⚠️ Alertas']
+    assert events and events[0][0] == 'INFO'


### PR DESCRIPTION
## Summary
- Add `metrics_dashboard` module with `show_global_metrics` to present ROI, ranking, alerts and global Telethon state.
- Extend database layer with `get_global_metrics` and `get_alerts` aggregation helpers.
- Introduce regression tests for metrics dashboard access control and content.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893719197c883339e8c1fac593ab48a