### PR TITLE
Add role-based main interface and store helpers

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,10 @@ def show_main_interface(chat_id, user_id):
         )
 
     stores = db.get_user_stores(user_id)
+    if not stores and role != "superadmin":
+        _send_long_message(chat_id, "No tienes tiendas disponibles.")
+        return
+
     for store in stores:
         status_emoji = "🟢" if store.get("status") else "🔴"
         telethon_emoji = "🤖" if store.get("telethon_active") else "⚪"


### PR DESCRIPTION
## Summary
- Show main interface with per-store buttons using InlineKeyboardMarkup
- Provide helpers to resolve user role and stores
- Split messages over Telegram's 4096 char limit
- Use new interface when handling `/start`
- Gracefully handle empty store list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937a92dc08833397cf45525932ea78