### PR TITLE
Improve superadmin dashboard handling

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -257,17 +257,31 @@ def show_superadmin_dashboard(chat_id, user_id):
     lines.append(header)
     table = '\n'.join(lines)
 
+    key = telebot.types.InlineKeyboardMarkup()
+    # Asegurar máximo de 3 botones por fila
+    try:
+        key.row_width = 3
+    except Exception:
+        pass
+    key.add(
+        telebot.types.InlineKeyboardButton(
+            text='Ver todas las tiendas', callback_data='admin_list_shops'
+        ),
+        telebot.types.InlineKeyboardButton(
+            text='Crear nueva', callback_data='admin_create_shop'
+        ),
+        telebot.types.InlineKeyboardButton(
+            text='Config Telethon global', callback_data='admin_telethon_config'
+        ),
+    )
+
     MAX = 4096
     for i in range(0, len(table), MAX):
-        bot.send_message(chat_id, table[i:i+MAX])
-
-    key = telebot.types.InlineKeyboardMarkup()
-    key.add(
-        telebot.types.InlineKeyboardButton(text='Ver todas las tiendas', callback_data='admin_list_shops'),
-        telebot.types.InlineKeyboardButton(text='Crear nueva', callback_data='admin_create_shop'),
-        telebot.types.InlineKeyboardButton(text='Config Telethon global', callback_data='admin_telethon_config'),
-    )
-    bot.send_message(chat_id, 'Opciones de gestión:', reply_markup=key)
+        chunk = table[i : i + MAX]
+        if i + MAX >= len(table):
+            bot.send_message(chat_id, chunk, reply_markup=key)
+        else:
+            bot.send_message(chat_id, chunk)
 
 
 def finalize_product_campaign(chat_id, shop_id, product):

--- a/main.py
+++ b/main.py
@@ -449,6 +449,7 @@ def inline(callback):
 
         if callback.data == 'select_store_main':
             adminka.show_superadmin_dashboard(callback.message.chat.id, callback.from_user.id)
+            return
 
         elif callback.message.chat.id in in_admin:
             adminka.ad_inline(callback.data, callback.message.chat.id, callback.message.message_id)


### PR DESCRIPTION
## Summary
- refactor `show_superadmin_dashboard` to chunk long outputs and limit keyboard rows
- ensure central router handles `select_store_main`

## Testing
- `PYTHONPATH=. pytest tests/test_admin_access.py::test_superadmin_dashboard_access tests/test_admin_access.py::test_superadmin_dashboard_denied -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68937c5c24f083339167009e0ca6d901