### PR TITLE
feat: centralize cancel navigation

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -768,15 +768,21 @@ def in_adminka(chat_id, message_text, username, name_user):
             show_discount_menu(chat_id)
 
         elif message_text == 'Cambiar texto':
-            key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='GLOBAL_CANCEL'))
-            bot.send_message(chat_id, 'Envíe el nuevo texto de descuento:', reply_markup=key)
+            key = nav_system.create_universal_navigation(chat_id, 'discount_change_text')
+            bot.send_message(
+                chat_id,
+                'Envíe el nuevo texto de descuento:',
+                reply_markup=key,
+            )
             set_state(chat_id, 33, 'discount')
 
         elif message_text == 'Cambiar porcentaje':
-            key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='GLOBAL_CANCEL'))
-            bot.send_message(chat_id, 'Envíe el nuevo porcentaje de descuento:', reply_markup=key)
+            key = nav_system.create_universal_navigation(chat_id, 'discount_change_percent')
+            bot.send_message(
+                chat_id,
+                'Envíe el nuevo porcentaje de descuento:',
+                reply_markup=key,
+            )
             set_state(chat_id, 34, 'discount')
 
         elif message_text in ('Ocultar precios tachados', 'Mostrar precios tachados'):
@@ -789,9 +795,12 @@ def in_adminka(chat_id, message_text, username, name_user):
             show_discount_menu(chat_id)
 
         elif 'Nuevo descuento' == message_text:
-            key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='GLOBAL_CANCEL'))
-            bot.send_message(chat_id, 'Ingrese porcentaje de descuento:', reply_markup=key)
+            key = nav_system.create_universal_navigation(chat_id, 'discount_new')
+            bot.send_message(
+                chat_id,
+                'Ingrese porcentaje de descuento:',
+                reply_markup=key,
+            )
             set_state(chat_id, 71, 'discount')
 
         elif 'Renombrar categoría' == message_text:
@@ -2581,9 +2590,12 @@ def text_analytics(message_text, chat_id):
                 return
             with open(f'data/Temp/{chat_id}_discount.txt', 'w', encoding='utf-8') as f:
                 f.write(str(percent))
-            key = telebot.types.InlineKeyboardMarkup()
-            key.add(telebot.types.InlineKeyboardButton(text='Cancelar', callback_data='GLOBAL_CANCEL'))
-            bot.send_message(chat_id, 'Duración en horas (0 permanente):', reply_markup=key)
+            key = nav_system.create_universal_navigation(chat_id, 'discount_duration')
+            bot.send_message(
+                chat_id,
+                'Duración en horas (0 permanente):',
+                reply_markup=key,
+            )
             set_state(chat_id, 72, 'discount')
 
         elif sost_num == 72:

--- a/tests/test_admin_menu_text.py
+++ b/tests/test_admin_menu_text.py
@@ -51,7 +51,10 @@ def test_navigation_buttons_present(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, 'telebot', stub)
 
-    markup = nav_system.create_universal_navigation(1, 'admin_menu')
+    actions = [('B', 'b')]
+    markup = nav_system.create_universal_navigation(1, 'admin_menu', actions)
     texts = [b.text for b in markup.buttons]
+    assert 'B' in texts
     assert '🏠 Inicio' in texts
     assert '❌ Cancelar' in texts
+    assert nav_system.get_quick_actions(1) == actions

--- a/tests/test_home_button.py
+++ b/tests/test_home_button.py
@@ -50,7 +50,10 @@ def test_universal_navigation_buttons(monkeypatch):
     )
     monkeypatch.setitem(sys.modules, 'telebot', stub)
 
-    markup = nav_system.create_universal_navigation(1, 'test')
+    actions = [('A', 'a')]
+    markup = nav_system.create_universal_navigation(1, 'test', actions)
     texts = [b.text for b in markup.buttons]
+    assert 'A' in texts
     assert '🏠 Inicio' in texts
     assert '❌ Cancelar' in texts
+    assert nav_system.get_quick_actions(1) == actions


### PR DESCRIPTION
## Summary
- centralize discount flows through UnifiedNavigationSystem
- cover quick-action behavior in navigation tests

## Testing
- `PYTHONPATH=. pytest tests/test_home_button.py tests/test_admin_menu_text.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689388130f388333b8c766365a513258