### PR TITLE
feat: chunk and paginate long dashboard messages

### DIFF
--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -7,7 +7,9 @@ from utils.message_chunker import send_long_message
 def show_global_metrics(chat_id, user_id):
     """Display global ROI, ranking, alerts and Telethon state."""
     if db.get_user_role(user_id) != 'superadmin':
-        bot.send_message(chat_id, '❌ Acceso restringido.')
+        # Ensure even short warnings go through the chunker for
+        # consistent behaviour across the codebase.
+        send_long_message(bot, chat_id, '❌ Acceso restringido.')
         return
 
     metrics = db.get_global_metrics()

--- a/tests/test_long_stock_messages.py
+++ b/tests/test_long_stock_messages.py
@@ -2,19 +2,42 @@ from utils.message_chunker import send_long_message
 
 
 class DummyBot:
+    """Minimal bot stub that records messages and markups."""
+
     def __init__(self):
         self.messages = []
+        self.markups = []
 
-    def send_message(self, chat_id, text, parse_mode=None, reply_markup=None):
+    def send_message(self, chat_id, text, parse_mode=None, reply_markup=None):  # pragma: no cover - simple recorder
         self.messages.append(text)
+        self.markups.append(reply_markup)
 
 
 def test_send_long_message_splits_long_messages():
-    long_text = 'X' * 9000
+    """Large messages are paginated and reconstructed correctly."""
+
+    long_text = "\n".join(f"Producto {i}" for i in range(1, 1200))  # simulate stock list
     bot = DummyBot()
+
     send_long_message(bot, 1, long_text)
 
-    assert len(bot.messages) == 3
-    assert bot.messages[0].startswith('1/3')
-    reconstructed = ''.join(m.split('\n', 1)[1] if '\n' in m else m for m in bot.messages)
+    assert len(bot.messages) > 1  # should split into chunks
+    assert bot.messages[0].startswith("1/")  # first chunk includes page header
+    reconstructed = "".join(m.split("\n", 1)[1] if "\n" in m else m for m in bot.messages)
     assert reconstructed == long_text
+
+
+def test_markup_only_on_first_chunk():
+    """Reply markup must be attached only to the first message chunk."""
+
+    text = "X" * 9000
+    bot = DummyBot()
+    markup = object()
+
+    send_long_message(bot, 7, text, markup=markup)
+
+    assert bot.markups[0] is markup
+    assert all(m is None for m in bot.markups[1:])
+    assert bot.messages[0].startswith("1/")
+    assert bot.messages[-1].startswith(f"{len(bot.messages)}/")
+

--- a/utils/message_chunker.py
+++ b/utils/message_chunker.py
@@ -1,11 +1,14 @@
 import math
 
 
-def send_long_message(bot, chat_id, text, markup=None, parse_mode=None):
-    """Send text in chunks safe for Telegram (<4096 chars).
+def send_long_message(bot, chat_id, text, markup=None, parse_mode=None, **kwargs):
+    """Send ``text`` split into 4096‑character chunks.
 
-    Adds a simple page header ("1/3") when the text spans multiple messages.
-    The reply markup, if provided, is only attached to the first message.
+    Each chunk is prefixed with a simple ``"1/3"`` style header when the
+    message spans multiple parts.  Any ``reply_markup`` is only attached to the
+    first chunk.  Additional keyword arguments are forwarded to
+    :meth:`bot.send_message` allowing callers to specify parameters such as
+    ``disable_web_page_preview``.
     """
     if text is None:
         text = ""
@@ -27,4 +30,5 @@ def send_long_message(bot, chat_id, text, markup=None, parse_mode=None):
             header + chunk,
             reply_markup=markup if idx == 1 else None,
             parse_mode=parse_mode,
+            **kwargs,
         )


### PR DESCRIPTION
## Summary
- add utility to split long messages with page headers and optional markup
- unify dashboard messaging to go through the chunker
- cover long-stock message pagination and markup behaviour in tests

## Testing
- `PYTHONPATH=. pytest tests/test_long_stock_messages.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938ceddb0083339b1f40e1237618c0