### PR TITLE
Add superadmin dashboard routing and access tests

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -303,6 +303,13 @@ def show_superadmin_dashboard(chat_id, user_id):
             bot.send_message(chat_id, chunk)
 
 
+# Registrar el dashboard principal del superadmin en el sistema de navegación
+nav_system.register(
+    "select_store_main",
+    lambda chat_id, uid: show_superadmin_dashboard(chat_id, uid),
+)
+
+
 def finalize_product_campaign(chat_id, shop_id, product):
     """Crear campaña de producto usando la información almacenada."""
     info = dop.get_product_full_info(product, shop_id)

--- a/main.py
+++ b/main.py
@@ -475,11 +475,11 @@ def inline(callback):
                 getattr(callback.from_user, 'first_name', ''),
             )
             return
-
         if callback.data == 'select_store_main':
-            adminka.show_superadmin_dashboard(callback.message.chat.id, callback.from_user.id)
+            nav_system.handle(
+                'select_store_main', callback.message.chat.id, callback.from_user.id
+            )
             return
-
         elif callback.message.chat.id in in_admin:
             adminka.ad_inline(callback.data, callback.message.chat.id, callback.message.message_id)
 

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -2,6 +2,7 @@ from tests.test_shop_info import setup_main
 import types
 import os
 import config
+from navigation import nav_system
 
 
 def test_adm_command_requires_permissions(monkeypatch, tmp_path):
@@ -137,3 +138,10 @@ def test_superadmin_dashboard_denied(monkeypatch, tmp_path):
                 messages.append(c[2].get('text', ''))
 
     assert any('Acceso restringido' in m for m in messages)
+
+
+def test_select_store_main_registered(monkeypatch, tmp_path):
+    import sys
+    sys.modules.pop('adminka', None)
+    setup_main(monkeypatch, tmp_path)
+    assert 'select_store_main' in nav_system._actions


### PR DESCRIPTION
## Summary
- Integrate the superadmin dashboard into the navigation router and add registration
- Route `select_store_main` callback through the router for superadmins
- Expand admin access tests to cover superadmin routing registration

## Testing
- `PYTHONPATH=. pytest tests/test_admin_access.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689393f317f883338977bff60745366f