### PR TITLE
Handle long Telegram messages with chunking utility

### DIFF
--- a/tests/test_long_stock_messages.py
+++ b/tests/test_long_stock_messages.py
@@ -1,3 +1,9 @@
+import pathlib
+import sys
+
+# Ensure the repository root is on the import path so ``utils`` can be resolved
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
 from utils.message_chunker import send_long_message
 
 

--- a/utils/message_chunker.py
+++ b/utils/message_chunker.py
@@ -2,12 +2,13 @@ import math
 
 
 def send_long_message(bot, chat_id, text, markup=None, parse_mode=None, **kwargs):
-    """Send ``text`` split into 4096‑character chunks.
+    """Send ``text`` respecting Telegram's 4096‑character message limit.
 
-    Each chunk is prefixed with a simple ``"1/3"`` style header when the
-    message spans multiple parts.  Any ``reply_markup`` is only attached to the
-    first chunk.  Additional keyword arguments are forwarded to
-    :meth:`bot.send_message` allowing callers to specify parameters such as
+    The helper transparently paginates long messages.  When more than one chunk
+    is required a simple ``"1/N"`` header is prepended to each part and any
+    ``reply_markup`` is attached only to the first message to avoid duplicated
+    keyboards.  Extra keyword arguments are forwarded to
+    :meth:`bot.send_message` so callers can specify flags like
     ``disable_web_page_preview``.
     """
     if text is None:


### PR DESCRIPTION
## Summary
- document and refine `send_long_message` helper to split texts into Telegram-safe chunks
- verify long messages and reply markups through dedicated tests

## Testing
- `pytest tests/test_long_stock_messages.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893adde29848333b8721f74fc4dfaa0