### PR TITLE
Add global metrics dashboard with unified logging

### DIFF
--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -15,6 +15,7 @@ def show_global_metrics(chat_id, user_id):
         # Ensure even short warnings go through the chunker for
         # consistent behaviour across the codebase.
         send_long_message(bot, chat_id, '❌ Acceso restringido.')
+        db.log_event('WARNING', f'user {user_id} denied global_metrics')
         return
 
     metrics = db.get_global_metrics()


### PR DESCRIPTION
## Summary
- log denied access to the global metrics dashboard
- show global metrics with quick actions and message chunking

## Testing
- `pytest tests/test_metrics_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6893af9abcc0833380c5602ac91d180a