### PR TITLE
Enhance dashboards with time-series metrics

### DIFF
--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -2,6 +2,7 @@ import db
 from bot_instance import bot
 from navigation import nav_system
 from utils.message_chunker import send_long_message
+from utils.ascii_chart import sparkline
 
 
 def show_global_metrics(chat_id, user_id):
@@ -20,14 +21,24 @@ def show_global_metrics(chat_id, user_id):
 
     metrics = db.get_global_metrics()
     alerts = db.get_alerts()
+    sales_ts = db.get_sales_timeseries()
+    camp_ts = db.get_campaign_timeseries()
 
     lines = [
         '🌐 *Métricas Globales*',
         f"ROI: {metrics.get('roi', 0)}",
         f"Telethon: {metrics.get('telethon_active', 0)}/{metrics.get('telethon_total', 0)} activos",
-        '',
-        '*Ranking:*',
     ]
+    if sales_ts:
+        vals = [s['total'] for s in sales_ts]
+        delta = vals[-1] - (vals[-2] if len(vals) > 1 else 0)
+        lines.append(f"💹 Ventas 7d: {sparkline(vals)} ({delta:+})")
+    if camp_ts:
+        vals = [c['count'] for c in camp_ts]
+        delta = vals[-1] - (vals[-2] if len(vals) > 1 else 0)
+        lines.append(f"📣 Campañas 7d: {sparkline(vals)} ({delta:+})")
+
+    lines.extend(['', '*Ranking:*'])
     for idx, r in enumerate(metrics.get('ranking', []), 1):
         lines.append(f"{idx}. {r.get('name')} - ${r.get('total')}")
 

--- a/tests/test_db_timeseries.py
+++ b/tests/test_db_timeseries.py
@@ -1,0 +1,39 @@
+import os, sqlite3, sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import db, files
+
+
+def _setup(tmp_path, monkeypatch):
+    db_path = tmp_path / 'main.db'
+    monkeypatch.setattr(files, 'main_db', str(db_path))
+    os.makedirs(tmp_path, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute('CREATE TABLE purchases (id INTEGER, price INTEGER, timestamp TEXT, shop_id INTEGER)')
+    cur.execute('CREATE TABLE send_logs (id INTEGER, sent_date TEXT, shop_id INTEGER)')
+    conn.commit()
+    return conn
+
+
+def test_timeseries_functions(tmp_path, monkeypatch):
+    conn = _setup(tmp_path, monkeypatch)
+    cur = conn.cursor()
+    cur.executemany('INSERT INTO purchases VALUES (?,?,?,?)', [
+        (1, 10, '2024-01-01T00:00:00', 1),
+        (2, 20, '2024-01-02T00:00:00', 1),
+    ])
+    cur.executemany('INSERT INTO send_logs VALUES (?,?,?)', [
+        (1, '2024-01-01', 1),
+        (2, '2024-01-02', 1),
+        (3, '2024-01-02', 1),
+    ])
+    conn.commit()
+    conn.close()
+
+    db.close_connection()
+    sales = db.get_sales_timeseries(1, 7)
+    camps = db.get_campaign_timeseries(1, 7)
+    assert sales[-1]['total'] == 20
+    assert camps[-1]['count'] == 2

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -47,6 +47,16 @@ def test_show_global_metrics_content(monkeypatch):
         'get_alerts',
         lambda limit=5: [{'level': 'ERROR', 'message': 'Algo'}],
     )
+    monkeypatch.setattr(
+        metrics_dashboard.db,
+        'get_sales_timeseries',
+        lambda store_id=None, days=7: [{'day': 'd1', 'total': 1}, {'day': 'd2', 'total': 3}],
+    )
+    monkeypatch.setattr(
+        metrics_dashboard.db,
+        'get_campaign_timeseries',
+        lambda store_id=None, days=7: [{'day': 'd1', 'count': 0}, {'day': 'd2', 'count': 2}],
+    )
     events = []
     monkeypatch.setattr(
         metrics_dashboard.db,
@@ -80,6 +90,8 @@ def test_show_global_metrics_content(monkeypatch):
     assert 'Shop1' in text
     assert 'Telethon: 1/2 activos' in text
     assert 'ERROR: Algo' in text
+    assert '💹' in text
+    assert '📣' in text
 
     markup = dummy.messages[0][2]
     buttons = [btn for row in markup.keyboard for btn in row if btn.callback_data == 'global_metrics']

--- a/tests/test_store_dashboard.py
+++ b/tests/test_store_dashboard.py
@@ -1,0 +1,42 @@
+import types, sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+
+def test_store_dashboard_shows_timeseries(monkeypatch):
+    calls = []
+
+    class Bot:
+        def send_message(self, chat_id, text=None, reply_markup=None, **kw):
+            calls.append(text)
+
+    class Markup:
+        def __init__(self):
+            self.buttons = []
+
+        def add(self, *btns):
+            self.buttons.extend(btns)
+
+    class Button:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    telebot_stub = types.SimpleNamespace(
+        TeleBot=lambda *a, **k: Bot(),
+        types=types.SimpleNamespace(InlineKeyboardMarkup=Markup, InlineKeyboardButton=Button),
+    )
+    monkeypatch.setitem(sys.modules, 'telebot', telebot_stub)
+    bot = telebot_stub.TeleBot()
+    monkeypatch.setitem(sys.modules, 'bot_instance', types.SimpleNamespace(bot=bot))
+
+    import importlib, adminka
+    importlib.reload(adminka)
+    monkeypatch.setattr(adminka.db, 'get_store_stats', lambda sid: {'products': 1, 'purchases': 2, 'revenue': 30})
+    monkeypatch.setattr(adminka.telethon_manager, 'get_stats', lambda sid: {'active': True, 'sent': 0})
+    monkeypatch.setattr(adminka.db, 'get_sales_timeseries', lambda sid, days=7: [{'day':'a','total':1},{'day':'b','total':2}])
+    monkeypatch.setattr(adminka.db, 'get_campaign_timeseries', lambda sid, days=7: [{'day':'a','count':0},{'day':'b','count':1}])
+
+    adminka.show_store_dashboard_unified(1, 1, 'Shop')
+    text = calls[0]
+    assert '💰' in text and '📣' in text

--- a/utils/ascii_chart.py
+++ b/utils/ascii_chart.py
@@ -1,0 +1,12 @@
+BLOCKS = "▁▂▃▄▅▆▇█"
+
+def sparkline(values):
+    """Return a small ASCII sparkline for a list of numeric values."""
+    if not values:
+        return ""
+    mn = min(values)
+    mx = max(values)
+    if mn == mx:
+        return BLOCKS[0] * len(values)
+    scale = (len(BLOCKS) - 1) / (mx - mn)
+    return ''.join(BLOCKS[int((v - mn) * scale)] for v in values)


### PR DESCRIPTION
## Summary
- add ASCII sparkline helper and DB time-series queries for sales and campaigns
- expand global and store dashboards with daily deltas and trend graphs
- cover new metrics with unit tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b37b17b88333819af12a232f532f