### PR TITLE
Add BI reporting with superadmin access and tests

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -5,6 +5,7 @@ import telethon_config
 import telethon_manager
 import datetime
 from utils.ascii_chart import sparkline
+from business_intelligence import generate_bi_report
 from advertising_system.admin_integration import (
     manager as advertising,
     set_shop_id,
@@ -309,6 +310,9 @@ def show_superadmin_dashboard(chat_id, user_id):
         telebot.types.InlineKeyboardButton(
             text='Config Telethon global', callback_data='admin_telethon_config'
         ),
+        telebot.types.InlineKeyboardButton(
+            text='\U0001F4CA BI Reporte', callback_data='admin_bi_report'
+        ),
     )
 
     MAX = 4096
@@ -324,6 +328,21 @@ def show_superadmin_dashboard(chat_id, user_id):
 nav_system.register(
     "select_store_main",
     lambda chat_id, uid: show_superadmin_dashboard(chat_id, uid),
+)
+
+
+def show_bi_report(chat_id, user_id):
+    """Send the Business Intelligence report to the super admin."""
+    if user_id != config.admin_id:
+        bot.send_message(chat_id, '❌ Acceso restringido.')
+        return
+    report = generate_bi_report()
+    bot.send_message(chat_id, report, parse_mode='Markdown')
+
+
+nav_system.register(
+    'admin_bi_report',
+    lambda chat_id, uid: show_bi_report(chat_id, uid),
 )
 
 

--- a/business_intelligence.py
+++ b/business_intelligence.py
@@ -1,0 +1,56 @@
+import db
+from utils.ascii_chart import sparkline
+
+
+def generate_bi_report():
+    """Generate a simple Business Intelligence report.
+
+    The report compares all stores computing a basic ROI (based on revenue),
+    creates a ranking and shows the sales trend using ASCII sparklines.
+
+    Returns:
+        str: Multi-line textual summary.
+    """
+    con = db.get_db_connection()
+    cur = con.cursor()
+    try:
+        cur.execute("SELECT id, name FROM shops")
+        shops = cur.fetchall()
+    except Exception:
+        shops = []
+
+    stats = []
+    for sid, name in shops:
+        try:
+            cur.execute(
+                "SELECT COALESCE(SUM(price),0) FROM purchases WHERE shop_id=?",
+                (sid,),
+            )
+            revenue = cur.fetchone()[0] or 0
+        except Exception:
+            revenue = 0
+
+        # Placeholder for costs; none are tracked currently
+        cost = 0
+        roi = revenue - cost
+
+        sales_ts = db.get_sales_timeseries(store_id=sid)
+        trend = sparkline([s["total"] for s in sales_ts]) if sales_ts else None
+
+        stats.append({
+            "shop_id": sid,
+            "name": name,
+            "roi": roi,
+            "revenue": revenue,
+            "trend": trend,
+        })
+
+    ranking = sorted(stats, key=lambda x: x["roi"], reverse=True)
+
+    lines = ["📊 *Reporte BI*", ""]
+    for idx, r in enumerate(ranking, 1):
+        line = f"{idx}. {r['name']} - ROI: {r['roi']}"
+        if r["trend"]:
+            line += f" ({r['trend']})"
+        lines.append(line)
+    return "\n".join(lines)

--- a/tests/test_bi_report.py
+++ b/tests/test_bi_report.py
@@ -1,0 +1,36 @@
+import pathlib, sys, sqlite3
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from business_intelligence import generate_bi_report
+import db
+
+
+def _setup_db():
+    con = sqlite3.connect(':memory:')
+    cur = con.cursor()
+    cur.execute('CREATE TABLE shops (id INTEGER PRIMARY KEY, name TEXT)')
+    cur.execute('CREATE TABLE purchases (shop_id INTEGER, price REAL, timestamp TEXT)')
+    cur.executemany('INSERT INTO shops (id, name) VALUES (?,?)', [(1, 'Shop1'), (2, 'Shop2')])
+    # Shop1 revenue 100
+    cur.executemany(
+        'INSERT INTO purchases (shop_id, price, timestamp) VALUES (?,?,?)',
+        [(1, 50, '2024-01-01'), (1, 50, '2024-01-02'), (2, 30, '2024-01-01'), (2, 20, '2024-01-02')],
+    )
+    con.commit()
+    return con
+
+
+def test_generate_bi_report_roi_and_ranking(monkeypatch):
+    con = _setup_db()
+    monkeypatch.setattr(db, 'get_db_connection', lambda: con)
+    monkeypatch.setattr(db, 'get_sales_timeseries', lambda store_id=None, days=7: [])
+
+    text = generate_bi_report()
+
+    assert 'ROI: 100' in text
+    assert 'ROI: 50' in text
+
+    lines = [l for l in text.splitlines() if l and l[0].isdigit()]
+    assert lines[0].startswith('1. Shop1')
+    assert lines[1].startswith('2. Shop2')


### PR DESCRIPTION
## Summary
- Implement `generate_bi_report` to compare shops and compute ROI, ranking, and sales trends
- Expose BI report through new "📊 BI Reporte" button in superadmin dashboard
- Test ROI calculation and ranking output of BI report

## Testing
- `python -m pytest tests/test_bi_report.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b5f025dc8333b0cc3de52b67b7ca