### PR TITLE
Implement alert monitoring and management

### DIFF
--- a/alert_manager.py
+++ b/alert_manager.py
@@ -1,0 +1,46 @@
+import config
+from bot_instance import bot
+import db
+
+
+def _check_thresholds():
+    """Scan database for conditions that should trigger alerts."""
+    con = db.get_db_connection()
+    cur = con.cursor()
+    db._ensure_shop_extra_columns(cur)
+    try:
+        cur.execute(
+            "SELECT id, name, max_campaigns_daily, current_campaigns_today, telethon_daemon_status FROM shops"
+        )
+        for sid, name, max_daily, current, daemon_status in cur.fetchall():
+            if max_daily and current >= max_daily:
+                msg = f"{name} excedió campañas: {current}/{max_daily}"
+                db.log_event("ALERT", msg, sid)
+                db.add_alert("ALERT", msg)
+            if daemon_status and str(daemon_status).lower() == "down":
+                msg = f"Daemon caído en {name}"
+                db.log_event("ALERT", msg, sid)
+                db.add_alert("ALERT", msg)
+    except Exception:
+        # If shops table doesn't exist or query fails we ignore silently
+        pass
+
+
+def dispatch_alerts():
+    """Send pending alerts to the SuperAdmin and store them if delivery fails."""
+    _check_thresholds()
+    pending = db.get_unsent_alerts()
+    if not pending:
+        return
+    sent_ids = []
+    for alert in pending:
+        try:
+            bot.send_message(
+                config.admin_id,
+                f"⚠️ {alert['level']}: {alert['message']}"
+            )
+            sent_ids.append(alert["id"])
+        except Exception:
+            # If sending fails, keep the alert unsent
+            db.log_event("ERROR", f"No se pudo enviar alerta: {alert['message']}")
+    db.mark_alerts_sent(sent_ids)

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -55,7 +55,7 @@ def show_global_metrics(chat_id, user_id):
         [
             ('🔄 Actualizar', 'global_metrics'),
             ('📊 Reportes', 'global_metrics'),
-            ('⚠️ Alertas', 'global_metrics'),
+            ('⚠️ Alertas', 'global_alerts'),
         ],
     )
     send_long_message(bot, chat_id, '\n'.join(lines), markup=key, parse_mode='Markdown')
@@ -67,3 +67,32 @@ def _global_metrics_nav(chat_id, _store_id=None):
 
 
 nav_system.register('global_metrics', _global_metrics_nav)
+
+
+def show_pending_alerts(chat_id, user_id):
+    """Display and clear pending alerts for the SuperAdmin."""
+    if db.get_user_role(user_id) != 'superadmin':
+        send_long_message(bot, chat_id, '❌ Acceso restringido.')
+        db.log_event('WARNING', f'user {user_id} denied alerts_view')
+        return
+
+    alerts = db.get_alerts(limit=50)
+    lines = ['⚠️ *Alertas Pendientes:*']
+    if alerts:
+        lines.extend(f"{a['level']}: {a['message']}" for a in alerts)
+    else:
+        lines.append('Ninguna')
+    db.clear_alerts()
+    key = nav_system.create_universal_navigation(
+        chat_id,
+        'global_alerts',
+        [('⬅️ Volver', 'global_metrics')],
+    )
+    send_long_message(bot, chat_id, '\n'.join(lines), markup=key, parse_mode='Markdown')
+
+
+def _global_alerts_nav(chat_id, _store_id=None):
+    show_pending_alerts(chat_id, chat_id)
+
+
+nav_system.register('global_alerts', _global_alerts_nav)

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -94,7 +94,8 @@ def test_show_global_metrics_content(monkeypatch):
     assert '📣' in text
 
     markup = dummy.messages[0][2]
-    buttons = [btn for row in markup.keyboard for btn in row if btn.callback_data == 'global_metrics']
-    texts = [b.text for b in buttons]
-    assert texts == ['🔄 Actualizar', '📊 Reportes', '⚠️ Alertas']
+    buttons = [(btn.text, btn.callback_data) for row in markup.keyboard for btn in row]
+    assert ('🔄 Actualizar', 'global_metrics') in buttons
+    assert ('📊 Reportes', 'global_metrics') in buttons
+    assert ('⚠️ Alertas', 'global_alerts') in buttons
     assert events and events[0][0] == 'INFO'


### PR DESCRIPTION
## Summary
- add dedicated `alert_manager` to scan shop status and dispatch alerts to the SuperAdmin
- persist alerts in new database table and allow clearing via metrics dashboard
- expose global "⚠️ Alertas" view for reviewing and clearing pending alerts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b81e8050833389fc7501f7b41c41