### PR TITLE
Integrate shop management callbacks with navigation system

### DIFF
--- a/main.py
+++ b/main.py
@@ -489,9 +489,9 @@ def inline(callback):
                 getattr(callback.from_user, 'first_name', ''),
             )
             return
-        if callback.data == 'select_store_main':
+        if callback.data in nav_system._actions:
             nav_system.handle(
-                'select_store_main', callback.message.chat.id, callback.from_user.id
+                callback.data, callback.message.chat.id, callback.from_user.id
             )
             return
         elif callback.data.startswith('SHOP_'):


### PR DESCRIPTION
## Summary
- Add `admin_list_shops` and `admin_create_shop` helpers and register them with the unified navigation system
- Use `nav_system` for BI report with explicit superadmin check
- Route callback queries generically through `nav_system`

## Testing
- `PYTHONPATH=. pytest tests/test_admin_access.py::test_superadmin_dashboard_access tests/test_admin_access.py::test_superadmin_dashboard_denied tests/test_admin_access.py::test_select_store_main_registered -q`
- `PYTHONPATH=. pytest tests/test_bi_report.py -q`
- `PYTHONPATH=. pytest tests/test_navigation_consistency.py -q`
- `PYTHONPATH=. pytest tests/test_home_button.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689422ddcef88333b363e249a216e059