### PR TITLE
Add universal back and refresh navigation

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -319,26 +319,13 @@ def show_superadmin_dashboard(chat_id, user_id):
     lines.append(header)
     table = '\n'.join(lines)
 
-    key = telebot.types.InlineKeyboardMarkup()
-    # Asegurar máximo de 3 botones por fila
-    try:
-        key.row_width = 3
-    except Exception:
-        pass
-    key.add(
-        telebot.types.InlineKeyboardButton(
-            text='Ver todas las tiendas', callback_data='admin_list_shops'
-        ),
-        telebot.types.InlineKeyboardButton(
-            text='Crear nueva', callback_data='admin_create_shop'
-        ),
-        telebot.types.InlineKeyboardButton(
-            text='Config Telethon global', callback_data='admin_telethon_config'
-        ),
-        telebot.types.InlineKeyboardButton(
-            text='\U0001F4CA BI Reporte', callback_data='admin_bi_report'
-        ),
-    )
+    quick = [
+        ('📋 Ver tiendas', 'admin_list_shops'),
+        ('➕ Crear', 'admin_create_shop'),
+        ('🧠 BI Reporte', 'admin_bi_report'),
+        ('🤖 Telethon', 'admin_telethon_config'),
+    ]
+    key = nav_system.create_universal_navigation(chat_id, 'superadmin_dashboard', quick)
 
     MAX = 4096
     for i in range(0, len(table), MAX):
@@ -350,6 +337,10 @@ def show_superadmin_dashboard(chat_id, user_id):
 
 
 # Registrar el dashboard principal del superadmin en el sistema de navegación
+nav_system.register(
+    "superadmin_dashboard",
+    lambda chat_id, uid: show_superadmin_dashboard(chat_id, uid),
+)
 nav_system.register(
     "select_store_main",
     lambda chat_id, uid: show_superadmin_dashboard(chat_id, uid),

--- a/main.py
+++ b/main.py
@@ -489,6 +489,22 @@ def inline(callback):
                 getattr(callback.from_user, 'first_name', ''),
             )
             return
+        if callback.data == 'GLOBAL_BACK':
+            prev = nav_system.back(callback.message.chat.id)
+            if prev:
+                nav_system.handle(prev, callback.message.chat.id, callback.from_user.id)
+            else:
+                send_main_menu(
+                    callback.message.chat.id,
+                    getattr(callback.from_user, 'username', ''),
+                    getattr(callback.from_user, 'first_name', ''),
+                )
+            return
+        if callback.data == 'GLOBAL_REFRESH':
+            current = nav_system.current(callback.message.chat.id)
+            if current:
+                nav_system.handle(current, callback.message.chat.id, callback.from_user.id)
+            return
         if callback.data in nav_system._actions:
             nav_system.handle(
                 callback.data, callback.message.chat.id, callback.from_user.id

--- a/metrics_dashboard.py
+++ b/metrics_dashboard.py
@@ -53,7 +53,6 @@ def show_global_metrics(chat_id, user_id):
         chat_id,
         'global_metrics',
         [
-            ('🔄 Actualizar', 'global_metrics'),
             ('📊 Reportes', 'global_metrics'),
             ('⚠️ Alertas', 'global_alerts'),
         ],

--- a/tests/test_metrics_dashboard.py
+++ b/tests/test_metrics_dashboard.py
@@ -95,7 +95,7 @@ def test_show_global_metrics_content(monkeypatch):
 
     markup = dummy.messages[0][2]
     buttons = [(btn.text, btn.callback_data) for row in markup.keyboard for btn in row]
-    assert ('🔄 Actualizar', 'global_metrics') in buttons
     assert ('📊 Reportes', 'global_metrics') in buttons
     assert ('⚠️ Alertas', 'global_alerts') in buttons
+    assert ('🔄 Actualizar', 'GLOBAL_REFRESH') in buttons
     assert events and events[0][0] == 'INFO'


### PR DESCRIPTION
## Summary
- replace SuperAdmin dashboard keyboard with universal navigation and quick actions
- extend navigation to include Back and Refresh controls and handle them globally
- adjust metrics dashboard and tests for new universal navigation behavior

## Testing
- `pytest tests/test_navigation_consistency.py tests/test_admin_access.py tests/test_metrics_dashboard.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d0726cec83338baae5daccef16a3