### PR TITLE
Add superadmin callback router and tests

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -415,6 +415,36 @@ def _admin_bi_report_nav(chat_id, user_id):
 nav_system.register("admin_bi_report", _admin_bi_report_nav)
 
 
+def route_superadmin_callback(callback_data, chat_id, user_id):
+    """Dispatch superadmin dashboard callbacks to their handlers.
+
+    Parameters
+    ----------
+    callback_data: str
+        Data received from the inline keyboard button.
+    chat_id: int
+        Identifier of the chat where the callback originated.
+    user_id: int
+        Identifier of the user triggering the callback.
+    """
+
+    if callback_data == "admin_telethon_config":
+        # Telethon configuration uses a dedicated handler that expects the
+        # original callback data as first argument.
+        telethon_config.global_telethon_config(callback_data, chat_id, user_id)
+        return
+
+    mapping = {
+        "admin_list_shops": admin_list_shops,
+        "admin_create_shop": admin_create_shop,
+        "admin_bi_report": show_bi_report,
+    }
+
+    handler = mapping.get(callback_data)
+    if handler:
+        handler(chat_id, user_id)
+
+
 def finalize_product_campaign(chat_id, shop_id, product):
     """Crear campaña de producto usando la información almacenada."""
     info = dop.get_product_full_info(product, shop_id)

--- a/tests/test_callback_routing.py
+++ b/tests/test_callback_routing.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+
+
+def test_superadmin_callback_routing(monkeypatch):
+    adminka = importlib.import_module('adminka')
+    called = []
+
+    monkeypatch.setattr(adminka, 'admin_list_shops', lambda c, u: called.append('list'))
+    monkeypatch.setattr(adminka, 'admin_create_shop', lambda c, u: called.append('create'))
+    monkeypatch.setattr(adminka, 'show_bi_report', lambda c, u: called.append('report'))
+    monkeypatch.setattr(
+        adminka.telethon_config,
+        'global_telethon_config',
+        lambda data, chat_id, user_id=None: called.append(data),
+    )
+
+    for data in [
+        'admin_list_shops',
+        'admin_create_shop',
+        'admin_bi_report',
+        'admin_telethon_config',
+    ]:
+        adminka.route_superadmin_callback(data, 1, 2)
+
+    assert called == ['list', 'create', 'report', 'admin_telethon_config']
+
+    # Remove module so subsequent tests can import a fresh copy with their own
+    # bot stubs.
+    sys.modules.pop('adminka', None)


### PR DESCRIPTION
## Summary
- Dispatch superadmin dashboard callbacks to their appropriate handlers
- Add tests ensuring each superadmin callback routes correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f80ff48c83338dd7aff0743e89d2