### PR TITLE
Implement unified navigation with concise quick actions

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -77,7 +77,7 @@ def show_main_admin_menu(chat_id):
         ('💰 Pagos', 'ad_pagos'),
         ('📊 Stats', 'ad_stats'),
         ('📣 Difusión', 'ad_difusion'),
-        ('Resumen de compradores', 'ad_resumen'),
+        ('👥 Clientes', 'ad_resumen'),
         ('📢 Marketing', 'ad_marketing'),
         ('🏷️ Categorías', 'ad_categorias'),
         ('💸 Descuentos', 'ad_descuentos'),
@@ -140,11 +140,11 @@ def show_store_dashboard_unified(chat_id, store_id, store_name):
     message = "\n".join(lines)
 
     quick_actions = [
-        ("Mi Tienda", "dash_shop_info"),
-        ("Productos", "dash_products"),
-        ("Marketing", "dash_marketing"),
-        ("Telethon", "dash_telethon"),
-        ("⬅️ Cambiar Tienda", "dash_change_store"),
+        ("🏪 Tienda", "dash_shop_info"),
+        ("📦 Productos", "dash_products"),
+        ("📢 Marketing", "dash_marketing"),
+        ("🤖 Telethon", "dash_telethon"),
+        ("⬅️ Cambiar", "dash_change_store"),
         ("🔄 Actualizar", f"dash_refresh_{store_id}"),
     ]
 
@@ -841,7 +841,7 @@ def in_adminka(chat_id, message_text, username, name_user):
             result = dop.get_daily_sales()
             bot.send_message(chat_id, result, parse_mode='Markdown')
 
-        elif 'Resumen de compradores' == message_text:
+        elif '👥 Clientes' == message_text:
             lines = dop.get_buyers_summary(shop_id)
             if not lines:
                 bot.send_message(chat_id, 'No hay compras registradas.')
@@ -3158,7 +3158,7 @@ nav_system.register('ad_producto', lambda chat_id, store_id: in_adminka(chat_id,
 nav_system.register('ad_pagos', lambda chat_id, store_id: in_adminka(chat_id, '💰 Pagos', None, None))
 nav_system.register('ad_stats', lambda chat_id, store_id: in_adminka(chat_id, '📊 Stats', None, None))
 nav_system.register('ad_difusion', lambda chat_id, store_id: in_adminka(chat_id, '📣 Difusión', None, None))
-nav_system.register('ad_resumen', lambda chat_id, store_id: in_adminka(chat_id, 'Resumen de compradores', None, None))
+nav_system.register('ad_resumen', lambda chat_id, store_id: in_adminka(chat_id, '👥 Clientes', None, None))
 nav_system.register('ad_marketing', lambda chat_id, store_id: in_adminka(chat_id, '📢 Marketing', None, None))
 nav_system.register('ad_categorias', lambda chat_id, store_id: in_adminka(chat_id, '🏷️ Categorías', None, None))
 nav_system.register('ad_descuentos', lambda chat_id, store_id: in_adminka(chat_id, '💸 Descuentos', None, None))

--- a/main.py
+++ b/main.py
@@ -74,9 +74,9 @@ def send_main_menu(chat_id, username, name):
     """Enviar el mensaje de inicio con el teclado principal"""
     quick_actions = [
         ('🛍️ Catálogo', 'Ir al catálogo de productos'),
-        ('📜 Mis compras', 'Ver mis compras'),
-        ('🔍 Buscar productos', 'Buscar productos'),
-        ('Cambiar tienda', 'Cambiar tienda'),
+        ('📜 Compras', 'Ver mis compras'),
+        ('🔍 Buscar', 'Buscar productos'),
+        ('🔄 Cambiar', 'Cambiar tienda'),
     ]
     key = nav_system.create_universal_navigation(chat_id, 'main_menu', quick_actions)
     if dop.check_message('start'):

--- a/navigation.py
+++ b/navigation.py
@@ -65,25 +65,43 @@ class UnifiedNavigationSystem:
         import telebot
 
         markup = telebot.types.InlineKeyboardMarkup()
-        for text, callback in quick_actions:
-            markup.add(
-                telebot.types.InlineKeyboardButton(text=text, callback_data=callback)
-            )
+
+        # Render quick actions, packing at most three buttons per row for a
+        # consistent layout across the bot.
+        for i in range(0, len(quick_actions), 3):
+            row = [
+                telebot.types.InlineKeyboardButton(text=t, callback_data=c)
+                for t, c in quick_actions[i : i + 3]
+            ]
+            markup.add(*row)
+
+        # Standard navigation controls (back, refresh, home, cancel).  These
+        # are also packed into rows of three to keep the keyboard compact.
         controls = []
         if has_history:
             controls.append(
-                telebot.types.InlineKeyboardButton(text='⬅️ Atrás', callback_data='GLOBAL_BACK')
+                telebot.types.InlineKeyboardButton(
+                    text='⬅️ Atrás', callback_data='GLOBAL_BACK'
+                )
             )
         controls.append(
-            telebot.types.InlineKeyboardButton(text='🔄 Actualizar', callback_data='GLOBAL_REFRESH')
+            telebot.types.InlineKeyboardButton(
+                text='🔄 Actualizar', callback_data='GLOBAL_REFRESH'
+            )
         )
         controls.append(
-            telebot.types.InlineKeyboardButton(text='🏠 Inicio', callback_data='Volver al inicio')
+            telebot.types.InlineKeyboardButton(
+                text='🏠 Inicio', callback_data='Volver al inicio'
+            )
         )
         controls.append(
-            telebot.types.InlineKeyboardButton(text='❌ Cancelar', callback_data='GLOBAL_CANCEL')
+            telebot.types.InlineKeyboardButton(
+                text='❌ Cancelar', callback_data='GLOBAL_CANCEL'
+            )
         )
-        markup.add(*controls)
+
+        for i in range(0, len(controls), 3):
+            markup.add(*controls[i : i + 3])
         return markup
 
     def get_quick_actions(self, chat_id, page=None):

--- a/tests/test_change_shop.py
+++ b/tests/test_change_shop.py
@@ -8,7 +8,7 @@ def test_main_menu_has_change_button(monkeypatch, tmp_path):
 
     main.send_main_menu(5, 'u', 'N')
     buttons = calls[-1][2]["reply_markup"].buttons
-    assert any('Cambiar tienda' in b.text for b in buttons)
+    assert any('🔄 Cambiar' in b.text for b in buttons)
 
 
 def test_change_shop_callback_invokes_list(monkeypatch, tmp_path):

--- a/tests/test_navigation_consistency.py
+++ b/tests/test_navigation_consistency.py
@@ -43,12 +43,19 @@ def _patch_telebot(monkeypatch):
 def test_universal_navigation_structure(monkeypatch):
     _patch_telebot(monkeypatch)
     nav_system.reset(1)
-    markup = nav_system.create_universal_navigation(1, 'p1', [('🔍 Buscar', 'search')])
+    actions = [('A', 'a'), ('B', 'b'), ('C', 'c'), ('D', 'd')]
+    markup = nav_system.create_universal_navigation(1, 'p1', actions)
     data = markup.to_dict()['inline_keyboard']
+    assert len(data[0]) == 3  # first three quick actions
+    assert len(data[1]) == 1  # remaining quick action
     assert [b['text'] for b in data[-1]] == ['🔄 Actualizar', '🏠 Inicio', '❌ Cancelar']
+    assert all(len(row) <= 3 for row in data)
+
     markup = nav_system.create_universal_navigation(1, 'p2')
     data = markup.to_dict()['inline_keyboard']
-    assert [b['text'] for b in data[-1]] == ['⬅️ Atrás', '🔄 Actualizar', '🏠 Inicio', '❌ Cancelar']
+    assert [b['text'] for b in data[-2]] == ['⬅️ Atrás', '🔄 Actualizar', '🏠 Inicio']
+    assert [b['text'] for b in data[-1]] == ['❌ Cancelar']
+    assert all(len(row) <= 3 for row in data)
 
 
 def test_dashboard_quick_action_labels(monkeypatch):

--- a/tests/test_product_search.py
+++ b/tests/test_product_search.py
@@ -10,7 +10,7 @@ def test_menu_has_search_button(monkeypatch, tmp_path):
 
     main.send_main_menu(5, 'user', 'Name')
     buttons = calls[-1][2]['reply_markup'].buttons
-    assert any('Buscar productos' in b.text for b in buttons)
+    assert any('🔍 Buscar' in b.text for b in buttons)
 
 
 def test_search_flow_returns_results(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Pack quick actions and system controls into rows of three in `UnifiedNavigationSystem`
- Streamline main and admin dashboards to use concise, emoji-led quick action labels
- Add navigation tests verifying row limits and control layout; adjust existing tests to new labels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d71f4f1c8333b334ce3f51aa1fad