### PR TITLE
feat: improve telethon dashboard routing and tests

### DIFF
--- a/streaming_manager_bot.py
+++ b/streaming_manager_bot.py
@@ -10,43 +10,63 @@ class StreamingManagerBot:
 
     def __init__(self, bot_instance=bot):
         self.bot = bot_instance
+        # Mapping of callback prefixes to handler methods.  This makes it easy
+        # to register new quick actions while keeping :meth:`route_callback`
+        # concise.
+        self.router = {
+            "telethon_dashboard": self.quick_dashboard,
+            "telethon_detect": self.quick_detect,
+            "start_auto_detection": self.quick_start_auto_detection,
+            "telethon_test": self.quick_test,
+            "telethon_restart": self.quick_restart,
+        }
 
+    # --- individual handlers -------------------------------------------------
+    def quick_dashboard(self, chat_id, store_id):
+        telethon_dashboard.show_telethon_dashboard(chat_id, store_id)
+
+    def quick_detect(self, chat_id, store_id):
+        summary = telethon_manager.detect_topics(store_id)
+        markup = telebot.types.InlineKeyboardMarkup()
+        markup.add(
+            telebot.types.InlineKeyboardButton(
+                text="Seleccionar todos",
+                callback_data=f"start_auto_detection_{store_id}_all",
+            ),
+            telebot.types.InlineKeyboardButton(
+                text="Personalizar",
+                callback_data=f"start_auto_detection_{store_id}_custom",
+            ),
+        )
+        send_long_message(self.bot, chat_id, summary, markup=markup)
+
+    def quick_start_auto_detection(self, chat_id, store_id, mode):
+        def progress(msg):
+            send_long_message(self.bot, chat_id, msg)
+
+        telethon_manager.start_auto_detection(store_id, mode, progress)
+        send_long_message(self.bot, chat_id, "Configuración confirmada")
+
+    def quick_test(self, chat_id, store_id):
+        telethon_manager.test_send(store_id)
+        send_long_message(self.bot, chat_id, "Envío de prueba enviado")
+
+    def quick_restart(self, chat_id, store_id):
+        telethon_manager.restart_daemon(store_id)
+        send_long_message(self.bot, chat_id, "Daemon reiniciado")
+
+    # --- router ---------------------------------------------------------------
     def route_callback(self, callback_data, chat_id):
         """Dispatch callbacks to the appropriate Telethon helper."""
 
-        if callback_data.startswith("telethon_dashboard_"):
-            store_id = int(callback_data.rsplit("_", 1)[1])
-            telethon_dashboard.show_telethon_dashboard(chat_id, store_id)
-        elif callback_data.startswith("telethon_detect_"):
-            store_id = int(callback_data.rsplit("_", 1)[1])
-            summary = telethon_manager.detect_topics(store_id)
-            markup = telebot.types.InlineKeyboardMarkup()
-            markup.add(
-                telebot.types.InlineKeyboardButton(
-                    text="Seleccionar todos",
-                    callback_data=f"start_auto_detection_{store_id}_all",
-                ),
-                telebot.types.InlineKeyboardButton(
-                    text="Personalizar",
-                    callback_data=f"start_auto_detection_{store_id}_custom",
-                ),
-            )
-            send_long_message(self.bot, chat_id, summary, markup=markup)
-        elif callback_data.startswith("start_auto_detection_"):
-            parts = callback_data.split("_")
-            store_id = int(parts[3])
-            mode = parts[4] if len(parts) > 4 else "all"
-
-            def progress(msg):
-                send_long_message(self.bot, chat_id, msg)
-
-            telethon_manager.start_auto_detection(store_id, mode, progress)
-            send_long_message(self.bot, chat_id, "Configuración confirmada")
-        elif callback_data.startswith("telethon_test_"):
-            store_id = int(callback_data.rsplit("_", 1)[1])
-            telethon_manager.test_send(store_id)
-            send_long_message(self.bot, chat_id, "Envío de prueba enviado")
-        elif callback_data.startswith("telethon_restart_"):
-            store_id = int(callback_data.rsplit("_", 1)[1])
-            telethon_manager.restart_daemon(store_id)
-            send_long_message(self.bot, chat_id, "Daemon reiniciado")
+        for prefix, handler in self.router.items():
+            if callback_data.startswith(prefix + "_"):
+                if prefix == "start_auto_detection":
+                    parts = callback_data.split("_")
+                    store_id = int(parts[3])
+                    mode = parts[4] if len(parts) > 4 else "all"
+                    handler(chat_id, store_id, mode)
+                else:
+                    store_id = int(callback_data.rsplit("_", 1)[1])
+                    handler(chat_id, store_id)
+                break

--- a/tests/test_topic_send.py
+++ b/tests/test_topic_send.py
@@ -304,12 +304,14 @@ def test_show_telethon_dashboard_buttons(monkeypatch):
     import importlib, telethon_dashboard
     importlib.reload(telethon_dashboard)
     monkeypatch.setattr(telethon_dashboard.telethon_manager, 'get_stats', lambda s: {'active': True, 'sent': 0})
+    monkeypatch.setattr(telethon_dashboard.db, 'get_store_topics', lambda sid: [])
 
     telethon_dashboard.show_telethon_dashboard(1, 5)
     markup = calls[0]
     cb_data = {b.callback_data for b in markup.buttons}
     assert f'telethon_detect_5' in cb_data
     assert f'telethon_test_5' in cb_data
+    assert f'telethon_restart_5' in cb_data
 
 
 def test_streaming_manager_routes_telethon_actions(monkeypatch):
@@ -333,14 +335,18 @@ def test_streaming_manager_routes_telethon_actions(monkeypatch):
         def send_message(self, chat_id, text, **kw):
             actions.append(('msg', chat_id, text))
 
+    monkeypatch.setattr(telethon_manager, 'restart_daemon', lambda sid: actions.append(('restart', sid)))
+
     sm = StreamingManagerBot(Bot())
     sm.route_callback('telethon_dashboard_3', 9)
     sm.route_callback('telethon_detect_3', 9)
     sm.route_callback('telethon_test_3', 9)
+    sm.route_callback('telethon_restart_3', 9)
 
     assert ('dash', 9, 3) in actions
     assert ('detect', 3) in actions
     assert ('test', 3) in actions
+    assert ('restart', 3) in actions
 
 
 def test_telethon_wizard_missing_credentials(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- show detailed Telethon metrics and configured topics in the dashboard
- refactor StreamingManagerBot with registered callbacks for telethon actions
- cover detect/test/restart flows in topic send tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b58c68fe883338281ddd6218ef4db