### PR TITLE
Add progress-aware Telethon wizard

### DIFF
--- a/tests/test_topic_send.py
+++ b/tests/test_topic_send.py
@@ -415,7 +415,7 @@ def test_telethon_wizard_activation(monkeypatch, tmp_path):
     monkeypatch.setattr(
         telethon_config.telethon_manager,
         'detect_topics',
-        lambda sid: actions.append(('detect', sid)),
+        lambda sid, progress_callback=None: actions.append(('detect', sid)),
     )
     monkeypatch.setattr(
         telethon_config.telethon_manager,
@@ -428,7 +428,6 @@ def test_telethon_wizard_activation(monkeypatch, tmp_path):
         lambda sid: actions.append(('activate', sid)),
     )
 
-    telethon_config.start_telethon_wizard(1, 7)
     telethon_config.start_telethon_wizard(1, 7)
     telethon_config.start_telethon_wizard(1, 7)
     telethon_config.start_telethon_wizard(1, 7)


### PR DESCRIPTION
## Summary
- Rework Telethon configuration wizard with persistent steps and progress bar
- Automatically select detected topics and paginate all messages
- Test wizard progress and automatic selection

## Testing
- `pytest tests/test_topic_detection.py -q`
- `pytest tests/test_topic_send.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b5aecc2508333b7c0f28dc3e9e477