### PR TITLE
Improve superadmin metrics panel

### DIFF
--- a/telethon_config.py
+++ b/telethon_config.py
@@ -49,7 +49,7 @@ def global_telethon_config(callback_data, chat_id, user_id=None):
     if user_id is None:
         user_id = chat_id
 
-    if callback_data == "admin_telethon_config":
+    if callback_data in ("admin_telethon_config", "global_telethon_config"):
         show_global_telethon_config(chat_id, user_id)
         return
 

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -166,7 +166,8 @@ def test_superadmin_dashboard_access(monkeypatch, tmp_path):
     assert any('Topics' in m and 'Campañas' in m and 'Daemon' in m for m in sent_texts)
     assert nav_system.current(5) == 'superadmin_dashboard'
     quick = nav_system.get_quick_actions(5, 'superadmin_dashboard')
-    assert [t for t, _ in quick] == ['📣 Marketing', '🤖 Telethon', '🧾 Reportes', '⚙️ Config']
+    texts = {t for t, _ in quick}
+    assert {'🏪 Tiendas', '➕ Crear Tienda', '📊 BI Reporte', '🤖 Telethon Global'}.issubset(texts)
 
     cb = types.SimpleNamespace(
         data='GLOBAL_REFRESH',

--- a/tests/test_superadmin_dashboard.py
+++ b/tests/test_superadmin_dashboard.py
@@ -1,0 +1,49 @@
+import os, sqlite3
+import adminka, config
+from navigation import nav_system
+from tests.test_shop_info import setup_main
+import files
+
+
+def test_superadmin_dashboard_metrics(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    config.admin_id = 1
+    dop.ensure_database_schema()
+    sid1 = dop.create_shop("S1", admin_id=1)
+    sid2 = dop.create_shop("S2", admin_id=1)
+    conn = sqlite3.connect(files.main_db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE platform_config (platform TEXT, is_active INTEGER, shop_id INTEGER)")
+    cur.execute("INSERT INTO platform_config (platform, is_active, shop_id) VALUES ('telethon',1,?)", (sid1,))
+    cur.execute("INSERT INTO platform_config (platform, is_active, shop_id) VALUES ('telethon',0,?)", (sid2,))
+    cur.execute("UPDATE shops SET telethon_daemon_status='running' WHERE id=?", (sid1,))
+    cur.execute("UPDATE shops SET telethon_daemon_status='stopped' WHERE id=?", (sid2,))
+    cur.execute(
+        "INSERT INTO purchases (id, username, name_good, amount, price, shop_id) VALUES (1,'u','g',1,50,?)",
+        (sid1,),
+    )
+    cur.execute(
+        "INSERT INTO store_topics (store_id, group_id, group_name, topic_id, topic_name) VALUES (?,?,?,?,?)",
+        (sid1, '1', 'g', 1, 't1'),
+    )
+    cur.execute(
+        "INSERT INTO campaigns (name, message_text, shop_id) VALUES ('c1','msg',?)",
+        (sid1,),
+    )
+    conn.commit()
+    conn.close()
+    os.environ['GLOBAL_CAMPAIGN_LIMIT'] = '5'
+    os.environ['GLOBAL_TOPIC_LIMIT'] = '10'
+    sent = []
+    monkeypatch.setattr(adminka, 'send_long_message', lambda b, cid, text, **kw: sent.append(text))
+    adminka.show_superadmin_dashboard(5, 1)
+    text = "\n".join(sent)
+    assert 'Ventas: 1/50' in text
+    assert 'Campañas: 1' in text
+    assert 'Topics: 1' in text
+    assert 'Daemons activos: 1/2' in text
+    assert 'Límite campañas/día: 5' in text
+    assert 'Topics máximos: 10' in text
+    quick = nav_system.get_quick_actions(5, 'superadmin_dashboard')
+    callbacks = {c for _, c in quick}
+    assert {'admin_list_shops', 'admin_create_shop', 'global_telethon_config', 'admin_bi_report'}.issubset(callbacks)

--- a/utils/professional_box.py
+++ b/utils/professional_box.py
@@ -1,0 +1,35 @@
+from typing import Iterable, Sequence
+
+
+def render_box(lines: Iterable[str], title: str | None = None) -> str:
+    """Render text inside a simple box for nicer messages.
+
+    Parameters
+    ----------
+    lines:
+        Iterable of lines to include inside the box.
+    title:
+        Optional title shown at the top separated by a horizontal rule.
+    """
+    # Ensure we have a list so it can be iterated multiple times
+    if isinstance(lines, str):
+        lines = [lines]
+    else:
+        lines = list(lines)
+
+    width = 0
+    for line in lines:
+        width = max(width, len(line))
+    if title:
+        width = max(width, len(title))
+    horiz = "─" * (width + 2)
+    top = f"┌{horiz}┐"
+    bottom = f"└{horiz}┘"
+    out_lines: list[str] = [top]
+    if title:
+        out_lines.append(f"│ {title.ljust(width)} │")
+        out_lines.append(f"├{horiz}┤")
+    for line in lines:
+        out_lines.append(f"│ {line.ljust(width)} │")
+    out_lines.append(bottom)
+    return "\n".join(out_lines)


### PR DESCRIPTION
## Summary
- Display global sales, campaign, topic and daemon counts in a boxed summary
- Add store management, Telethon control and BI report actions with restart option
- Provide utility `render_box` and tests for superadmin dashboard

## Testing
- `PYTHONPATH=. pytest tests/test_admin_access.py tests/test_superadmin_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b69b12cd0833385828dc101befdca