### PR TITLE
Expand Telethon dashboard with metrics and quick actions

### DIFF
--- a/streaming_manager_bot.py
+++ b/streaming_manager_bot.py
@@ -16,9 +16,12 @@ class StreamingManagerBot:
         self.router = {
             "telethon_dashboard": self.quick_dashboard,
             "telethon_detect": self.quick_detect,
+            "quick_detect": self.quick_detect,
             "start_auto_detection": self.quick_start_auto_detection,
             "telethon_test": self.quick_test,
+            "quick_test": self.quick_test,
             "telethon_restart": self.quick_restart,
+            "quick_restart": self.quick_restart,
         }
 
     # --- individual handlers -------------------------------------------------

--- a/telethon_dashboard.py
+++ b/telethon_dashboard.py
@@ -16,39 +16,80 @@ def show_telethon_dashboard(chat_id, store_id):
     """
 
     stats = telethon_manager.get_stats(store_id) or {}
+    try:
+        daily = db.get_daily_campaign_counts(store_id)
+    except Exception:
+        daily = {"current": 0, "max": 0}
+    try:
+        alerts = db.get_alerts(limit=3)
+    except Exception:
+        alerts = []
     topics = db.get_store_topics(store_id)
 
     lines = [
         "🤖 *Panel de Telethon*",
         "",
         "*Métricas:*",
+        f"📆 Campañas hoy: {daily.get('current', 0)}",
+        f"⚡ {daily.get('current', 0)}/{daily.get('max', 0)}",
         f"🔁 Daemon: {stats.get('daemon', '-')}",
+        f"⏱️ Conexión: {stats.get('last_activity', '-')}",
         f"🔌 API: {'OK' if stats.get('api') else 'No'}",
         f"🧵 Topics: {stats.get('topics', 0)}",
         f"📤 Último envío: {stats.get('last_send', '-')}",
         "",
         "*Acciones rápidas:*",
         "- Detectar topics",
-        "",
-        "*Mantenimiento:*",
         "- Prueba de envío",
         "- Reiniciar daemon",
+        "",
+        "*Mantenimiento:*",
+        "- Limpiar sesiones",
+        "- Exportar configuración",
+        "- Importar configuración",
         "",
         "*Topics configurados:*",
     ]
 
     if topics:
         for t in topics:
+            success = total = 0
+            try:
+                group_key = f"{t.get('group_id', '')}:{t.get('topic_id', 0)}"
+                con = db.get_db_connection()
+                cur = con.cursor()
+                cur.execute(
+                    "SELECT COUNT(*) FROM send_logs WHERE platform='telethon' AND shop_id=? AND group_id=?",
+                    (store_id, group_key),
+                )
+                total = cur.fetchone()[0] or 0
+                cur.execute(
+                    "SELECT COUNT(*) FROM send_logs WHERE platform='telethon' AND status='success' AND shop_id=? AND group_id=?",
+                    (store_id, group_key),
+                )
+                success = cur.fetchone()[0] or 0
+            except Exception:
+                pass
             lines.append(
-                f"• {t.get('group_name', '')} ({t.get('topic_id', 0)})"
+                f"• {t.get('group_name', '')} ({t.get('topic_id', 0)}) - {success}/{total}"
             )
     else:
         lines.append("Ninguno")
 
+    lines.extend([
+        "",
+        "*Alertas recientes:*",
+    ])
+    if alerts:
+        for a in alerts:
+            lines.append(f"⚠️ {a.get('message', '')}")
+    else:
+        lines.append("Sin alertas")
+
     quick_actions = [
-        ("🧵 Topics", f"telethon_detect_{store_id}"),
-        ("✉️ Prueba", f"telethon_test_{store_id}"),
-        ("♻️ Reiniciar", f"telethon_restart_{store_id}"),
+        ("🧵 Topics", f"quick_detect_{store_id}"),
+        ("✉️ Prueba", f"quick_test_{store_id}"),
+        ("♻️ Reiniciar", f"quick_restart_{store_id}"),
     ]
 
     markup = nav_system.create_universal_navigation(

--- a/telethon_manager.py
+++ b/telethon_manager.py
@@ -31,7 +31,15 @@ def get_stats(shop_id):
     available, keeping the function robust for tests where a minimal schema is
     used."""
 
-    stats = {"active": False, "sent": 0, "daemon": "-", "api": False, "topics": 0, "last_send": "-"}
+    stats = {
+        "active": False,
+        "sent": 0,
+        "daemon": "-",
+        "api": False,
+        "topics": 0,
+        "last_send": "-",
+        "last_activity": "-",
+    }
     try:
         con = db.get_db_connection()
         cur = con.cursor()
@@ -54,10 +62,16 @@ def get_stats(shop_id):
         except Exception:
             pass
         try:
-            cur.execute("SELECT telethon_daemon_status FROM shops WHERE id=?", (shop_id,))
+            cur.execute(
+                "SELECT telethon_daemon_status, telethon_last_activity FROM shops WHERE id=?",
+                (shop_id,),
+            )
             row = cur.fetchone()
-            if row and row[0]:
-                stats["daemon"] = row[0]
+            if row:
+                if row[0]:
+                    stats["daemon"] = row[0]
+                if row[1]:
+                    stats["last_activity"] = row[1]
         except Exception:
             pass
         try:

--- a/tests/test_shop_info.py
+++ b/tests/test_shop_info.py
@@ -89,6 +89,7 @@ def setup_main(monkeypatch, tmp_path):
     sys.modules.pop("db", None)
     sys.modules.pop("dop", None)
     sys.modules.pop("main", None)
+    sys.modules.pop("adminka", None)
     dop = importlib.import_module("dop")
     main = importlib.import_module("main")
 

--- a/tests/test_topic_detection.py
+++ b/tests/test_topic_detection.py
@@ -144,7 +144,7 @@ def test_route_callback_detect_topics(monkeypatch):
     monkeypatch.setattr(telethon_manager, "detect_topics", lambda s: "resumen")
 
     smb = streaming_module.StreamingManagerBot(DummyBot())
-    smb.route_callback("telethon_detect_5", 99)
+    smb.route_callback("quick_detect_5", 99)
 
     assert msgs == ["resumen"]
     buttons = [b.text for row in markups[0].keyboard for b in row]

--- a/tests/test_topic_send.py
+++ b/tests/test_topic_send.py
@@ -305,13 +305,15 @@ def test_show_telethon_dashboard_buttons(monkeypatch):
     importlib.reload(telethon_dashboard)
     monkeypatch.setattr(telethon_dashboard.telethon_manager, 'get_stats', lambda s: {'active': True, 'sent': 0})
     monkeypatch.setattr(telethon_dashboard.db, 'get_store_topics', lambda sid: [])
+    monkeypatch.setattr(telethon_dashboard.db, 'get_daily_campaign_counts', lambda sid: {'current': 0, 'max': 0})
+    monkeypatch.setattr(telethon_dashboard.db, 'get_alerts', lambda limit=3: [])
 
     telethon_dashboard.show_telethon_dashboard(1, 5)
     markup = calls[0]
     cb_data = {b.callback_data for b in markup.buttons}
-    assert f'telethon_detect_5' in cb_data
-    assert f'telethon_test_5' in cb_data
-    assert f'telethon_restart_5' in cb_data
+    assert f'quick_detect_5' in cb_data
+    assert f'quick_test_5' in cb_data
+    assert f'quick_restart_5' in cb_data
 
 
 def test_streaming_manager_routes_telethon_actions(monkeypatch):
@@ -339,9 +341,9 @@ def test_streaming_manager_routes_telethon_actions(monkeypatch):
 
     sm = StreamingManagerBot(Bot())
     sm.route_callback('telethon_dashboard_3', 9)
-    sm.route_callback('telethon_detect_3', 9)
-    sm.route_callback('telethon_test_3', 9)
-    sm.route_callback('telethon_restart_3', 9)
+    sm.route_callback('quick_detect_3', 9)
+    sm.route_callback('quick_test_3', 9)
+    sm.route_callback('quick_restart_3', 9)
 
     assert ('dash', 9, 3) in actions
     assert ('detect', 3) in actions


### PR DESCRIPTION
## Summary
- Enrich Telethon dashboard with campaign limits, daemon/connection info, maintenance tools and recent alerts
- Track per-topic send success counts and expose new quick_detect/quick_test/quick_restart actions
- Route new quick callbacks and include last activity metric in Telethon stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b6fc320b0833395848a2453ffe5e1