### PR TITLE
Ensure professional box utility is Python 3.8 compatible

### DIFF
--- a/utils/professional_box.py
+++ b/utils/professional_box.py
@@ -1,7 +1,7 @@
-from typing import Iterable, Sequence
+from typing import Iterable, List, Optional
 
 
-def render_box(lines: Iterable[str], title: str | None = None) -> str:
+def render_box(lines: Iterable[str], title: Optional[str] = None) -> str:
     """Render text inside a simple box for nicer messages.
 
     Parameters
@@ -25,7 +25,7 @@ def render_box(lines: Iterable[str], title: str | None = None) -> str:
     horiz = "─" * (width + 2)
     top = f"┌{horiz}┐"
     bottom = f"└{horiz}┘"
-    out_lines: list[str] = [top]
+    out_lines: List[str] = [top]
     if title:
         out_lines.append(f"│ {title.ljust(width)} │")
         out_lines.append(f"├{horiz}┤")


### PR DESCRIPTION
## Summary
- use `Optional` and `List` from `typing` to support Python 3.8
- update `render_box` signature and internal list typing

## Testing
- `python3.8 -m pytest` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b779b73f88333925dbd161ce9edec