### PR TITLE
Always show store selector on /start

### DIFF
--- a/main.py
+++ b/main.py
@@ -260,7 +260,6 @@ def message_send(message):
     role = db.get_user_role(user_id)
     admin_list = dop.get_adminlist()
     is_admin = user_id in admin_list or role == "superadmin"
-    has_shop = dop.user_has_shop(user_id)
 
     first_word = ""
     if isinstance(message.text, str):
@@ -289,17 +288,11 @@ def message_send(message):
                 show_product_details(message.chat.id, product, shop_id)
                 dop.user_loger(chat_id=message.chat.id)
                 return
-
-        if is_admin:
-            show_main_interface(message.chat.id, user_id)
-        elif has_shop:
-            send_main_menu(
-                message.chat.id,
-                message.chat.username,
-                message.from_user.first_name,
-            )
-        else:
-            show_shop_selection(message.chat.id)
+        if dop.get_sost(message.chat.id):
+            with shelve.open(files.sost_bd) as bd:
+                if str(message.chat.id) in bd:
+                    del bd[str(message.chat.id)]
+        show_shop_selection(message.chat.id)
         dop.user_loger(chat_id=message.chat.id)
         return
 

--- a/tests/test_start_message.py
+++ b/tests/test_start_message.py
@@ -6,7 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parent))
 from test_shop_info import setup_main
 
 
-def test_client_gets_main_menu(monkeypatch, tmp_path):
+def test_start_shows_selector_existing_user(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()
     sid = dop.create_shop("S1", admin_id=1)
@@ -18,10 +18,10 @@ def test_client_gets_main_menu(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_send(chat_id, username, name):
-        called["args"] = (chat_id, username, name)
+    def fake_select(chat_id, message=None):
+        called["args"] = (chat_id, message)
 
-    monkeypatch.setattr(main, "send_main_menu", fake_send)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
 
     class Msg:
         def __init__(self):
@@ -31,10 +31,10 @@ def test_client_gets_main_menu(monkeypatch, tmp_path):
             self.content_type = "text"
 
     main.message_send(Msg())
-    assert called.get("args") == (5, "u", "N")
+    assert called.get("args") == (5, None)
 
 
-def test_admin_start_shows_interface(monkeypatch, tmp_path):
+def test_admin_start_shows_selector(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()
     sid = dop.create_shop("S1", admin_id=1)
@@ -46,10 +46,10 @@ def test_admin_start_shows_interface(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_interface(chat_id, user_id):
-        called["args"] = (chat_id, user_id)
+    def fake_select(chat_id, message=None):
+        called["args"] = (chat_id, message)
 
-    monkeypatch.setattr(main, "show_main_interface", fake_interface)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
 
     class Msg:
         def __init__(self):
@@ -59,7 +59,7 @@ def test_admin_start_shows_interface(monkeypatch, tmp_path):
             self.content_type = "text"
 
     main.message_send(Msg())
-    assert called.get("args") == (1, 1)
+    assert called.get("args") == (1, None)
 
 
 def test_shop_callback_loads_dashboard(monkeypatch, tmp_path):

--- a/tests/test_start_welcome.py
+++ b/tests/test_start_welcome.py
@@ -3,7 +3,7 @@ import types
 from tests.test_shop_info import setup_main
 
 
-def test_start_sends_main_menu_existing_user(monkeypatch, tmp_path):
+def test_start_shows_selector_existing_user(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()
 
@@ -14,12 +14,12 @@ def test_start_sends_main_menu_existing_user(monkeypatch, tmp_path):
     monkeypatch.setattr(dop, "get_sost", lambda cid: False)
     monkeypatch.setattr(dop, "user_loger", lambda chat_id=0: None)
 
-    called = {}
+    called = []
 
-    def fake_menu(cid, username, name):
-        called["args"] = (cid, username, name)
+    def fake_select(cid, message=None):
+        called.append((cid, message))
 
-    monkeypatch.setattr(main, "send_main_menu", fake_menu)
+    monkeypatch.setattr(main, "show_shop_selection", fake_select)
 
     class Msg:
         def __init__(self):
@@ -30,7 +30,7 @@ def test_start_sends_main_menu_existing_user(monkeypatch, tmp_path):
 
     main.message_send(Msg())
 
-    assert called.get("args") == (5, "u", "N")
+    assert called == [(5, None)]
 
 
 def test_start_shows_selection_new_user(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Display the shop selection menu for all users when `/start` is received and clear any existing session state.
- Update start message tests to expect the selector for both regular users and admins.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b808206a48333a83960ca8011cade