### PR TITLE
Add store navigation buttons to superadmin dashboard

### DIFF
--- a/main.py
+++ b/main.py
@@ -486,6 +486,28 @@ def inline(callback):
                 callback.data, callback.message.chat.id, callback.from_user.id
             )
             return
+        elif callback.data.startswith('view_store_'):
+            shop_id = int(callback.data.replace('view_store_', ''))
+            dop.set_user_shop(callback.message.chat.id, shop_id)
+            try:
+                con = db.get_db_connection()
+                cur = con.cursor()
+                cur.execute("SELECT name FROM shops WHERE id = ?", (shop_id,))
+                row = cur.fetchone()
+                name = row[0] if row else str(shop_id)
+            except Exception:
+                name = str(shop_id)
+            adminka.show_store_dashboard_unified(
+                callback.message.chat.id, shop_id, name
+            )
+            return
+        elif callback.data.startswith('admin_store_'):
+            shop_id = int(callback.data.replace('admin_store_', ''))
+            dop.set_user_shop(callback.message.chat.id, shop_id)
+            if callback.message.chat.id not in in_admin:
+                in_admin.append(callback.message.chat.id)
+            adminka.show_main_admin_menu(callback.message.chat.id)
+            return
         elif callback.data.startswith('SHOP_'):
             shop_id = int(callback.data.replace('SHOP_', ''))
             dop.set_user_shop(callback.message.chat.id, shop_id)

--- a/tests/test_superadmin_dashboard.py
+++ b/tests/test_superadmin_dashboard.py
@@ -1,5 +1,7 @@
-import os, sqlite3
-import adminka, config
+import os, sqlite3, types, sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import config
 from navigation import nav_system
 from tests.test_shop_info import setup_main
 import files
@@ -7,6 +9,7 @@ import files
 
 def test_superadmin_dashboard_metrics(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    import adminka
     config.admin_id = 1
     dop.ensure_database_schema()
     sid1 = dop.create_shop("S1", admin_id=1)
@@ -35,15 +38,44 @@ def test_superadmin_dashboard_metrics(monkeypatch, tmp_path):
     os.environ['GLOBAL_CAMPAIGN_LIMIT'] = '5'
     os.environ['GLOBAL_TOPIC_LIMIT'] = '10'
     sent = []
-    monkeypatch.setattr(adminka, 'send_long_message', lambda b, cid, text, **kw: sent.append(text))
+    def fake_send(bot, cid, text, markup=None, **kw):
+        sent.append((text, markup))
+    monkeypatch.setattr(adminka, 'send_long_message', fake_send)
     adminka.show_superadmin_dashboard(5, 1)
-    text = "\n".join(sent)
+    text = "\n".join(t for t, _ in sent)
     assert 'Ventas: 1/50' in text
     assert 'Campañas: 1' in text
     assert 'Topics: 1' in text
     assert 'Daemons activos: 1/2' in text
     assert 'Límite campañas/día: 5' in text
     assert 'Topics máximos: 10' in text
+    markup = sent[-1][1]
+    buttons = {(b.text, b.callback_data) for b in getattr(markup, 'buttons', [])}
+    assert (f'📊 S1', f'view_store_{sid1}') in buttons
+    assert (f'⚙️ Administrar', f'admin_store_{sid1}') in buttons
+    assert (f'📊 S2', f'view_store_{sid2}') in buttons
+    assert (f'⚙️ Administrar', f'admin_store_{sid2}') in buttons
     quick = nav_system.get_quick_actions(5, 'superadmin_dashboard')
     callbacks = {c for _, c in quick}
     assert {'admin_list_shops', 'admin_create_shop', 'global_telethon_config', 'admin_bi_report'}.issubset(callbacks)
+
+    called = {}
+    monkeypatch.setattr(adminka, 'show_store_dashboard_unified', lambda cid, sid, name: called.setdefault('view', (cid, sid, name)))
+    monkeypatch.setattr(adminka, 'show_main_admin_menu', lambda cid: called.setdefault('admin', cid))
+    cb_view = types.SimpleNamespace(
+        data=f'view_store_{sid1}',
+        message=types.SimpleNamespace(chat=types.SimpleNamespace(id=5), message_id=1),
+        id='1',
+        from_user=types.SimpleNamespace(id=1),
+    )
+    main.inline(cb_view)
+    assert called.get('view') == (5, sid1, 'S1')
+    cb_admin = types.SimpleNamespace(
+        data=f'admin_store_{sid2}',
+        message=types.SimpleNamespace(chat=types.SimpleNamespace(id=5), message_id=1),
+        id='2',
+        from_user=types.SimpleNamespace(id=1),
+    )
+    main.inline(cb_admin)
+    assert called.get('admin') == 5
+    assert 5 in main.in_admin


### PR DESCRIPTION
## Summary
- Replace superadmin dashboard store list with inline button pairs for viewing or administrating each shop
- Handle `view_store_*` and `admin_store_*` callbacks in the main inline handler
- Test superadmin dashboard buttons and callback behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b84a8a38c8333a86f2bbe530f23f9