### PR TITLE
Use unified store dashboard for shop admins

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -103,11 +103,6 @@ def show_main_admin_menu(chat_id):
     )
 
 
-def show_individual_admin_menu(chat_id):
-    """Alias del menú principal para administradores de tienda."""
-    return show_main_admin_menu(chat_id)
-
-
 def session_expired(chat_id):
     """Informar al usuario que la sesión expiró y volver al menú principal"""
     send_long_message(bot, chat_id, "❌ La sesión anterior se perdió.")
@@ -179,13 +174,20 @@ def show_store_dashboard_unified(chat_id, store_id, store_name):
 
     quick_actions = [
         ("🏪 Tienda", "dash_shop_info"),
-        ("📦 Productos", "dash_products"),
-        ("📢 Marketing", "dash_marketing"),
+        ("📦 Surtido", "ad_surtido"),
+        ("➕ Producto", "ad_producto"),
+        ("💰 Pagos", "ad_pagos"),
+        ("📊 Stats", "ad_stats"),
+        ("📣 Difusión", "ad_difusion"),
+        ("👥 Clientes", "ad_resumen"),
+        ("📢 Marketing", "ad_marketing"),
         ("🤖 Telethon", "dash_telethon"),
         ("🧾 Reportes", "dash_reports"),
         ("⚙️ Config", "dash_config"),
+        ("🏷️ Categorías", "ad_categorias"),
+        ("💸 Descuentos", "ad_descuentos"),
+        ("⚙️ Otros", "ad_otros"),
         ("⬅️ Cambiar", "dash_change_store"),
-        ("🔄 Actualizar", f"dash_refresh_{store_id}"),
     ]
 
     key = nav_system.create_universal_navigation(

--- a/main.py
+++ b/main.py
@@ -303,7 +303,17 @@ def message_send(message):
             if message.chat.id == config.admin_id:
                 show_main_interface(message.chat.id, user_id)
             else:
-                adminka.show_individual_admin_menu(message.chat.id)
+                shop_id = dop.get_shop_id(message.chat.id)
+                dop.set_user_shop(message.chat.id, shop_id)
+                try:
+                    con = db.get_db_connection()
+                    cur = con.cursor()
+                    cur.execute("SELECT name FROM shops WHERE id = ?", (shop_id,))
+                    row = cur.fetchone()
+                    name = row[0] if row else str(shop_id)
+                except Exception:
+                    name = str(shop_id)
+                adminka.show_store_dashboard_unified(message.chat.id, shop_id, name)
         else:
             bot.send_message(message.chat.id, '❌ No tienes permisos')
         return

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -54,10 +54,10 @@ def test_adm_command_allows_admin(monkeypatch, tmp_path):
 
     called = {}
 
-    def fake_menu(cid):
-        called['cid'] = cid
+    def fake_dash(cid, sid_arg, name):
+        called['args'] = (cid, sid_arg, name)
 
-    monkeypatch.setattr(adminka, 'show_individual_admin_menu', fake_menu)
+    monkeypatch.setattr(adminka, 'show_store_dashboard_unified', fake_dash)
 
     class Msg:
         def __init__(self):
@@ -68,7 +68,7 @@ def test_adm_command_allows_admin(monkeypatch, tmp_path):
 
     main.message_send(Msg())
 
-    assert called.get('cid') == 1
+    assert called.get('args') == (1, sid, 'S1')
 
 
 def test_adm_command_superadmin_dashboard(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Route `/adm` to `show_store_dashboard_unified` and persist selected shop
- Remove old `show_individual_admin_menu` alias
- Expand unified store dashboard with universal navigation shortcuts to all admin sections
- Update admin access test for new dashboard

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bd1e81a648333bbf40d81dd8ff741