### PR TITLE
Add discount and settings management panels

### DIFF
--- a/tests/test_navigation_consistency.py
+++ b/tests/test_navigation_consistency.py
@@ -194,7 +194,8 @@ def test_admin_menus_have_standard_buttons(monkeypatch):
         lambda: adminka.show_main_admin_menu(1),
         lambda: adminka.show_store_dashboard_unified(1, 1, 'Shop'),
         lambda: adminka.show_marketing_unified(1, 1),
-        lambda: adminka.show_discount_menu(1),
+        lambda: adminka.manage_discounts(1, 1),
+        lambda: adminka.show_other_settings(1, 1),
     ]
 
     for menu in menus:


### PR DESCRIPTION
## Summary
- Introduce `manage_discounts` panel with inline add/edit/delete actions
- Add `show_other_settings` panel for store details and admin management
- Register new callbacks and cover them in navigation consistency tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e182b6b08333a90b874b8b2f6137