### PR TITLE
Add dynamic product callback routing and tests

### DIFF
--- a/adminka.py
+++ b/adminka.py
@@ -812,6 +812,21 @@ def manage_products(chat_id, store_id):
     show_product_list(store_id, chat_id)
 
 
+def route_callback(callback_data, chat_id, store_id):
+    """Dispatch product-related callbacks to their handlers."""
+    router = {
+        "product_edit": lambda c, s, name: edit_product(c, s, name),
+        "product_toggle": lambda c, s, name: toggle_product(c, s, name),
+        "product_page": lambda c, s, page: show_product_list(s, c, int(page)),
+    }
+    for prefix, handler in router.items():
+        if callback_data.startswith(prefix + "_"):
+            arg = callback_data[len(prefix) + 1 :]
+            handler(chat_id, store_id, arg)
+            return True
+    return False
+
+
 """
 PayPal/Binance configuration
 ---------------------------

--- a/main.py
+++ b/main.py
@@ -496,20 +496,9 @@ def inline(callback):
                 callback.data, callback.message.chat.id, callback.from_user.id
             )
             return
-        elif callback.data.startswith('product_edit_'):
-            name = callback.data.replace('product_edit_', '')
-            store_id = dop.get_user_shop(callback.message.chat.id)
-            adminka.edit_product(callback.message.chat.id, store_id, name)
-            return
-        elif callback.data.startswith('product_toggle_'):
-            name = callback.data.replace('product_toggle_', '')
-            store_id = dop.get_user_shop(callback.message.chat.id)
-            adminka.toggle_product(callback.message.chat.id, store_id, name)
-            return
-        elif callback.data.startswith('product_page_'):
-            page = int(callback.data.replace('product_page_', ''))
-            store_id = dop.get_user_shop(callback.message.chat.id)
-            adminka.show_product_list(store_id, callback.message.chat.id, page)
+        elif adminka.route_callback(
+            callback.data, callback.message.chat.id, shop_id_cb
+        ):
             return
         elif callback.data.startswith('view_store_'):
             shop_id = int(callback.data.replace('view_store_', ''))

--- a/tests/test_callback_routing.py
+++ b/tests/test_callback_routing.py
@@ -1,5 +1,8 @@
 import importlib
+import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 
 def test_superadmin_callback_routing(monkeypatch):
@@ -27,4 +30,27 @@ def test_superadmin_callback_routing(monkeypatch):
 
     # Remove module so subsequent tests can import a fresh copy with their own
     # bot stubs.
+    sys.modules.pop('adminka', None)
+
+
+def test_product_callback_routing(monkeypatch):
+    adminka = importlib.import_module('adminka')
+    called = []
+
+    monkeypatch.setattr(
+        adminka, 'edit_product', lambda c, s, n: called.append(('edit', n))
+    )
+    monkeypatch.setattr(
+        adminka, 'toggle_product', lambda c, s, n: called.append(('toggle', n))
+    )
+    monkeypatch.setattr(
+        adminka, 'show_product_list', lambda s, c, p=1: called.append(('page', p))
+    )
+
+    assert adminka.route_callback('product_edit_X', 1, 2)
+    assert adminka.route_callback('product_toggle_Y', 1, 2)
+    assert adminka.route_callback('product_page_3', 1, 2)
+    assert called == [('edit', 'X'), ('toggle', 'Y'), ('page', 3)]
+    assert not adminka.route_callback('unknown', 1, 2)
+
     sys.modules.pop('adminka', None)


### PR DESCRIPTION
## Summary
- route product-related callbacks through a prefix-based router
- delegate product callbacks from main handler to the router
- extend callback routing tests to cover product actions

## Testing
- `pytest tests/test_callback_routing.py -q`
- `pytest tests/test_navigation_consistency.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8e491c63c8333b30058e9bab06873