### PR TITLE
Use timezone-aware datetimes in tests and logging

### DIFF
--- a/dop.py
+++ b/dop.py
@@ -425,7 +425,7 @@ def it_first(chat_id):
         return True
 
 def log(text):
-    time = str(datetime.datetime.utcnow())[:22]
+    time = str(datetime.datetime.now(datetime.UTC))[:22]
     try:
         with open(files.working_log, 'a', encoding='utf-8') as f:
             f.write(time + '    | ' + text + '\n')
@@ -2021,7 +2021,7 @@ def get_active_discount(product_or_cat_id, shop_id=1):
         else:
             category_id = product_or_cat_id
 
-        now = datetime.datetime.utcnow().isoformat()
+        now = datetime.datetime.now(datetime.UTC).isoformat()
         cur.execute(
             """
             SELECT percent FROM discounts
@@ -2042,7 +2042,7 @@ def update_active_discount_percent(new_percent, shop_id=1):
     try:
         con = db.get_db_connection()
         cur = con.cursor()
-        now = datetime.datetime.utcnow().isoformat()
+        now = datetime.datetime.now(datetime.UTC).isoformat()
         cur.execute(
             """
             UPDATE discounts

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:binance.ws.websocket_api
+    ignore::DeprecationWarning:websockets.legacy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import warnings
+
+warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module=r"^binance\.ws\.websocket_api"
+)
+warnings.filterwarnings(
+    "ignore", category=DeprecationWarning, module=r"^websockets\.legacy"
+)

--- a/tests/test_discount_update.py
+++ b/tests/test_discount_update.py
@@ -26,7 +26,7 @@ def test_toggle_discount_features(monkeypatch, tmp_path):
     conn.commit()
     conn.close()
 
-    start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    start = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
     dop.create_discount(10, start, None, None, 1)
     assert dop.get_active_discount('P', 1) == 10
 

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -16,7 +16,7 @@ def test_discount_creation_and_application(monkeypatch, tmp_path):
     conn.commit()
     conn.close()
 
-    start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    start = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
     dop.create_discount(20, start, None, 1, 1)
 
     assert dop.get_active_discount('Prod', 1) == 20


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(datetime.UTC)`
- filter third-party deprecation warnings in tests and pytest config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab549a68e483339ca15d15daa4a6f0