### PR TITLE
Add tests for marketing and telethon dashboards and global limits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/tests/test_product_campaign.py
+++ b/tests/test_product_campaign.py
@@ -185,6 +185,27 @@ def test_marketing_unified_splits_long_message(monkeypatch, tmp_path):
     assert send_calls[0][1][1].startswith("1/")
 
 
+def test_marketing_unified_shows_telethon_state(monkeypatch, tmp_path):
+    dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    sid = dop.create_shop("S1", admin_id=1)
+
+    monkeypatch.setattr(main.adminka, "bot", bot)
+    monkeypatch.setattr(main.adminka.advertising, "get_all_campaigns", lambda: [])
+    monkeypatch.setattr(
+        main.adminka,
+        "CampaignScheduler",
+        lambda *a, **k: types.SimpleNamespace(get_pending_sends=lambda: []),
+    )
+    monkeypatch.setattr(main.adminka.telethon_manager, "get_stats", lambda s: {"active": False})
+    monkeypatch.setattr(main.adminka.dop, "get_campaign_limit", lambda s: 0)
+
+    main.adminka.show_marketing_unified(sid, 5)
+    text = calls[-1][1][1]
+    assert "Telethon" in text
+    assert "Estado: Inactivo" in text
+
+
 def test_quick_actions_dispatch(monkeypatch, tmp_path):
     dop, main, calls, bot = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()

--- a/tests/test_telethon_config.py
+++ b/tests/test_telethon_config.py
@@ -1,0 +1,39 @@
+import types
+import telethon_config
+
+def test_show_global_telethon_config(monkeypatch):
+    calls = []
+
+    def fake_send(bot, chat_id, text, markup=None, parse_mode=None):
+        calls.append((text, markup))
+
+    monkeypatch.setattr(telethon_config, 'send_long_message', fake_send)
+    monkeypatch.setattr(telethon_config.db, 'get_global_telethon_status', lambda: {'b': '1', 'a': '2'})
+
+    class Markup:
+        def __init__(self):
+            self.buttons = []
+        def add(self, *btns):
+            self.buttons.extend(btns)
+
+    class Button:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    def create_nav(chat_id, key, actions):
+        markup = Markup()
+        for text, cb in actions:
+            markup.add(Button(text, cb))
+        return markup
+
+    monkeypatch.setattr(telethon_config.nav_system, 'create_universal_navigation', create_nav)
+    telethon_config.show_global_telethon_config(1, 1)
+
+    text, markup = calls[0]
+    lines = text.split('\n')
+    assert lines[1] == 'a: 2'
+    assert lines[2] == 'b: 1'
+    callbacks = {b.callback_data for b in markup.buttons}
+    assert 'global_restart_daemons' in callbacks
+    assert 'global_generate_report' in callbacks

--- a/tests/test_telethon_dashboard.py
+++ b/tests/test_telethon_dashboard.py
@@ -1,0 +1,34 @@
+import types
+import telethon_dashboard
+
+def test_telethon_dashboard_lists_topics_and_alerts(monkeypatch):
+    messages = []
+
+    def fake_send(bot, chat_id, text, markup=None, parse_mode=None):
+        messages.append(text)
+
+    monkeypatch.setattr(telethon_dashboard, 'send_long_message', fake_send)
+    monkeypatch.setattr(telethon_dashboard.nav_system, 'create_universal_navigation', lambda *a, **k: None)
+    monkeypatch.setattr(telethon_dashboard.telethon_manager, 'get_stats', lambda s: {'daemon': 'ok', 'last_activity': 'hoy', 'api': True, 'topics': 1, 'last_send': 'ayer'})
+    monkeypatch.setattr(telethon_dashboard.db, 'get_daily_campaign_counts', lambda sid: {'current': 2, 'max': 3})
+    monkeypatch.setattr(telethon_dashboard.db, 'get_alerts', lambda limit=3: [{'message': 'Algo'}])
+    monkeypatch.setattr(telethon_dashboard.db, 'get_store_topics', lambda sid: [{'group_id': 'g', 'topic_id': 1, 'group_name': 'G'}])
+
+    class DummyCursor:
+        def execute(self, *a, **k):
+            pass
+        def fetchone(self):
+            return [0]
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+
+    monkeypatch.setattr(telethon_dashboard.db, 'get_db_connection', lambda: DummyConn())
+
+    telethon_dashboard.show_telethon_dashboard(1, 5)
+    text = messages[0]
+    assert 'Campañas hoy: 2' in text
+    assert '⚡ 2/3' in text
+    assert 'G (1) - 0/0' in text
+    assert '⚠️ Algo' in text


### PR DESCRIPTION
## Summary
- cover marketing unified dashboard telethon status
- exercise Telethon dashboard metrics, topics and alerts
- test global Telethon configuration and add CI workflow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab66bc485083338eba623f442e4833