### PR TITLE
Use universal navigation for shop selection

### DIFF
--- a/main.py
+++ b/main.py
@@ -184,13 +184,10 @@ def show_main_interface(chat_id, user_id):
 def show_shop_selection(chat_id, message=None):
     """Mostrar listado de tiendas disponibles"""
     shops = dop.list_shops()
-    key = telebot.types.InlineKeyboardMarkup()
-    for sid, _, name in shops:
-        key.add(
-            telebot.types.InlineKeyboardButton(
-                text=name, callback_data=f"SELECT_SHOP_{sid}"
-            )
-        )
+    quick_actions = [(name, f"SELECT_SHOP_{sid}") for sid, _, name in shops]
+    key = nav_system.create_universal_navigation(
+        chat_id, "shop_selector", quick_actions=quick_actions
+    )
     if message is not None:
         ok = dop.safe_edit_message(
             bot, message, "Seleccione una tienda:", reply_markup=key
@@ -203,6 +200,14 @@ def show_shop_selection(chat_id, message=None):
             send_long_message(bot, chat_id, "Seleccione una tienda:", markup=key)
     else:
         send_long_message(bot, chat_id, "Seleccione una tienda:", markup=key)
+
+
+def _shop_selector_nav(chat_id, _store_id=None):
+    """Wrapper para refrescar la lista de tiendas."""
+    show_shop_selection(chat_id)
+
+
+nav_system.register("shop_selector", _shop_selector_nav)
 
 
 def show_product_details(chat_id, product_name, shop_id):

--- a/tests/test_start_message.py
+++ b/tests/test_start_message.py
@@ -168,6 +168,26 @@ def test_new_user_start_shows_selector(monkeypatch, tmp_path):
     assert called.get("args")[0] == 5
 
 
+def test_shop_selection_contains_nav_controls(monkeypatch, tmp_path):
+    dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
+    dop.ensure_database_schema()
+    dop.create_shop("S1", admin_id=1)
+
+    captured = {}
+
+    def fake_send(bot, chat_id, text, markup=None, **kwargs):
+        captured["markup"] = markup
+
+    monkeypatch.setattr(main, "send_long_message", fake_send)
+
+    main.show_shop_selection(1)
+
+    buttons = [b.text for b in captured["markup"].buttons]
+    assert "🔄 Actualizar" in buttons
+    assert "🏠 Inicio" in buttons
+    assert "❌ Cancelar" in buttons
+
+
 def test_interface_superadmin(monkeypatch, tmp_path):
     dop, main, calls, _ = setup_main(monkeypatch, tmp_path)
     dop.ensure_database_schema()


### PR DESCRIPTION
## Summary
- Replace manual shop selector keyboard with `nav_system.create_universal_navigation` and register page handler for refresh/back actions.
- Add regression test ensuring shop selection includes universal navigation buttons.

## Testing
- `pytest tests/test_start_message.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab7e8d22808333b2bd117231f92f13